### PR TITLE
Fix publish-release workflow and make release notes customer-facing only

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,7 +47,7 @@ jobs:
           echo "$NOTES" > /tmp/release_notes.txt
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e1cc45afe35dbb7bed808ca6aa2c48b0a # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Fixes

1. **Fixed `actions/checkout` SHA** — The SHA in `publish-release.yml` had a typo (`de0fac2e1cc45afe35dbb7bed808ca6aa2c48b0a`) that doesn't exist. Corrected to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` matching all other workflows.

2. **Ensure `published` label exists** — Added `gh label create` before applying the label so the workflow doesn't fail if the label hasn't been created yet.

3. **Release notes drafter: customer-facing only** — Updated the release-notes-drafter agent to:
   - Only include changes that directly affect the user experience
   - Explicitly exclude CI/CD workflows, developer tooling, internal refactors, dependency updates, and docs-only changes
   - Call `noop` if all changes are internal/non-customer-facing
   - Replaced `📦 Dependencies` category with `⚡ Performance`