### PR TITLE
Prevent SSR hydration mismatch by deferring Teleport rendering

### DIFF
--- a/resources/js/pages/Ai/Chat.vue
+++ b/resources/js/pages/Ai/Chat.vue
@@ -74,7 +74,7 @@ const currentConversationId = ref<string | null>(props.activeConversationId);
 const messagesContainer = ref<HTMLElement | null>(null);
 const showMobileSidebar = ref(false);
 
-// Defer Teleport rendering to avoid SSR hydration mismatch
+// Skip Teleport during SSR to prevent hydration mismatch
 const isMounted = ref(false);
 onMounted(() => {
     isMounted.value = true;


### PR DESCRIPTION
Defer the rendering of the Teleport component until the component is mounted to avoid hydration mismatches during server-side rendering.