### PR TITLE
Update PWA start_url to dashboard

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
                 background_color: '#ffffff',
                 display: 'standalone',
                 scope: '/',
-                start_url: '/',
+                start_url: '/dashboard',
                 icons: [
                     {
                         src: '/pwa-192x192.png',


### PR DESCRIPTION
Change the start_url in the PWA configuration to direct users to the dashboard instead of the root.