### PR TITLE
Change cache handler to NetworkFirst with network timeout

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -93,13 +93,14 @@ export default defineConfig({
                     },
                     {
                         urlPattern: /\.(?:js|css)$/i,
-                        handler: 'StaleWhileRevalidate',
+                        handler: 'NetworkFirst',
                         options: {
                             cacheName: 'static-resources',
                             expiration: {
                                 maxEntries: 50,
                                 maxAgeSeconds: 60 * 60 * 24 * 7,
                             },
+                            networkTimeoutSeconds: 3,
                         },
                     },
                 ],


### PR DESCRIPTION
Update the cache strategy for static resources to use NetworkFirst and introduce a network timeout to enhance resource loading reliability.