### PR TITLE
Add Wayfinder route generation to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Generate Application Key
         run: php artisan key:generate
 
+      - name: Generate Wayfinder Routes
+        run: php artisan wayfinder:generate
+
       - name: Build Assets
         run: npm run build
 
@@ -70,6 +73,7 @@ jobs:
 
             # Install Node dependencies and build assets
             npm ci
+            php artisan wayfinder:generate
             npm run build
 
             # Run database migrations


### PR DESCRIPTION
Incorporate a step to generate Wayfinder routes during the deployment process, ensuring routes are created both in the main job and during asset building.