### PR TITLE
Fix queue-worker restart for multi-process supervisor group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,7 +86,7 @@ jobs:
             php artisan event:cache
 
             # Restart queue workers, SSR server, and Nightwatch agent
-            sudo supervisorctl restart queue-worker
+            sudo supervisorctl restart queue-worker:*
             sudo supervisorctl restart ssr
             sudo supervisorctl restart nightwatch
 

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -31,7 +31,7 @@ php artisan view:cache
 php artisan event:cache
 
 echo "Restarting queue workers, SSR, and Nightwatch..."
-sudo supervisorctl restart queue-worker
+sudo supervisorctl restart queue-worker:*
 sudo supervisorctl restart ssr
 sudo supervisorctl restart nightwatch
 


### PR DESCRIPTION
Update the queue worker restart command to ensure it targets all processes in the supervisor group.