### PR TITLE
Fix Wayfinder generation during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,8 @@ jobs:
 
             # Install Node dependencies and build assets
             npm ci
+            php artisan optimize:clear
+            rm -rf resources/js/actions resources/js/routes resources/js/wayfinder
             php artisan wayfinder:generate
             npm run build
 


### PR DESCRIPTION
## Summary
- clear Laravel optimization caches before generating Wayfinder helpers during deploy
- remove stale ignored Wayfinder output before regeneration so new route/action helpers are created from the current code

## Verification
- rm -rf resources/js/actions resources/js/routes resources/js/wayfinder && php artisan optimize:clear && php artisan wayfinder:generate && npm run build