### PR TITLE
Enhance OpenFamilyFundReview tool with output template metadata

### DIFF
--- a/app/Mcp/Tools/OpenFamilyFundReview.php
+++ b/app/Mcp/Tools/OpenFamilyFundReview.php
@@ -17,6 +17,17 @@ class OpenFamilyFundReview extends Tool
 {
     use AuthorizesFamilyFundReview;
 
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $tool = parent::toArray();
+        $tool['_meta']['openai/outputTemplate'] = (new FamilyFundReviewApp)->uri();
+
+        return $tool;
+    }
+
     public function handle(Request $request): Response
     {
         $user = $this->authorizedUser($request);

--- a/tests/Feature/Mcp/FamilyFundReviewTest.php
+++ b/tests/Feature/Mcp/FamilyFundReviewTest.php
@@ -88,7 +88,8 @@ it('opens the review app with ui metadata', function () {
 
     expect($tool->name())->toBe('open-family-fund-review')
         ->and($metadata['resourceUri'] ?? null)->toBe((new FamilyFundReviewApp)->uri())
-        ->and($metadata['visibility'] ?? [])->toContain('model', 'app');
+        ->and($metadata['visibility'] ?? [])->toContain('model', 'app')
+        ->and($tool->toArray()['_meta']['openai/outputTemplate'] ?? null)->toBe((new FamilyFundReviewApp)->uri());
 });
 
 it('returns the app resource html', function () {


### PR DESCRIPTION
Add metadata for the output template in the OpenFamilyFundReview tool, improving the data structure returned by the `toArray` method. Update tests to verify the inclusion of this metadata.