### PR TITLE
[codex] Fix AI transcript name correction

### DIFF
--- a/resources/js/lib/transcript-corrections.js
+++ b/resources/js/lib/transcript-corrections.js
@@ -1,0 +1,21 @@
+export function correctTranscriptMemberNameCasing(text, memberNames = []) {
+    if (!memberNames.length) {
+        return text;
+    }
+
+    const nameTokens = new Map();
+
+    for (const fullName of memberNames) {
+        for (const part of fullName.split(/\s+/)) {
+            const token = part.trim();
+
+            if (token) {
+                nameTokens.set(token.toLowerCase(), token);
+            }
+        }
+    }
+
+    return text.replace(/\b[A-Za-z]{3,}\b/g, (word) => {
+        return nameTokens.get(word.toLowerCase()) ?? word;
+    });
+}

--- a/resources/js/pages/Ai/Chat.vue
+++ b/resources/js/pages/Ai/Chat.vue
@@ -20,6 +20,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { correctTranscriptMemberNameCasing } from '@/lib/transcript-corrections';
 import type { BreadcrumbItem } from '@/types';
 import { Head, router } from '@inertiajs/vue3';
 import { useStream } from '@laravel/stream-vue';
@@ -594,119 +595,8 @@ const pendingConfirmation = computed(() => {
     return patterns.some((phrase) => content.includes(phrase));
 });
 
-// Phonetic correction for speech recognition
-function soundex(str: string): string {
-    const s = str.toUpperCase().replace(/[^A-Z]/g, '');
-    if (!s) return '';
-
-    const map: Record<string, string> = {
-        B: '1',
-        F: '1',
-        P: '1',
-        V: '1',
-        C: '2',
-        G: '2',
-        J: '2',
-        K: '2',
-        Q: '2',
-        S: '2',
-        X: '2',
-        Z: '2',
-        D: '3',
-        T: '3',
-        L: '4',
-        M: '5',
-        N: '5',
-        R: '6',
-    };
-
-    let code = s[0];
-    let prev = map[s[0]] || '0';
-
-    for (let i = 1; i < s.length && code.length < 4; i++) {
-        const c = map[s[i]] || '0';
-        if (c !== '0' && c !== prev) {
-            code += c;
-        }
-        prev = c;
-    }
-
-    return code.padEnd(4, '0');
-}
-
-function levenshtein(a: string, b: string): number {
-    const m = a.length;
-    const n = b.length;
-    const dp: number[][] = Array.from(
-        { length: m + 1 },
-        () => Array(n + 1).fill(0) as number[],
-    );
-
-    for (let i = 0; i <= m; i++) dp[i][0] = i;
-    for (let j = 0; j <= n; j++) dp[0][j] = j;
-
-    for (let i = 1; i <= m; i++) {
-        for (let j = 1; j <= n; j++) {
-            dp[i][j] =
-                a[i - 1] === b[j - 1]
-                    ? dp[i - 1][j - 1]
-                    : 1 +
-                      Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
-        }
-    }
-
-    return dp[m][n];
-}
-
 function correctTranscript(text: string): string {
-    if (!props.memberNames.length) return text;
-
-    // Build lookup: split multi-word names into individual tokens and full names
-    const nameTokens = new Map<string, string>();
-    for (const fullName of props.memberNames) {
-        for (const part of fullName.split(/\s+/)) {
-            nameTokens.set(part.toLowerCase(), part);
-        }
-    }
-
-    return text.replace(/\b[A-Za-z]{3,}\b/g, (word) => {
-        const lower = word.toLowerCase();
-
-        // Skip if it's already an exact match (case-insensitive)
-        if (nameTokens.has(lower)) return nameTokens.get(lower)!;
-
-        const wordSoundex = soundex(word);
-        let bestMatch: string | null = null;
-        let bestDistance = Infinity;
-
-        for (const [tokenLower, original] of nameTokens) {
-            // Must share soundex code or be within 40% edit distance
-            const tokenSoundex = soundex(tokenLower);
-            const dist = levenshtein(lower, tokenLower);
-            const maxLen = Math.max(lower.length, tokenLower.length);
-            const threshold = Math.ceil(maxLen * 0.4);
-
-            if (
-                (wordSoundex === tokenSoundex || dist <= threshold) &&
-                dist < bestDistance &&
-                dist > 0
-            ) {
-                bestDistance = dist;
-                bestMatch = original;
-            }
-        }
-
-        // Only correct if the edit distance is reasonable (not too far off)
-        if (
-            bestMatch &&
-            bestDistance <=
-                Math.ceil(Math.max(word.length, bestMatch.length) * 0.4)
-        ) {
-            return bestMatch;
-        }
-
-        return word;
-    });
+    return correctTranscriptMemberNameCasing(text, props.memberNames);
 }
 
 // Voice input state

--- a/tests/Js/transcript-corrections.test.mjs
+++ b/tests/Js/transcript-corrections.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { correctTranscriptMemberNameCasing } from '../../resources/js/lib/transcript-corrections.js';
+
+describe('transcript corrections', () => {
+    it('preserves ordinary words that only sound similar to member names', () => {
+        const text = correctTranscriptMemberNameCasing(
+            'I am standing with my family today',
+            ['Sadiya Yusuf', 'Jamila Ahmed'],
+        );
+
+        assert.equal(text, 'I am standing with my family today');
+    });
+
+    it('only normalizes exact member-name token casing', () => {
+        const text = correctTranscriptMemberNameCasing(
+            'please show jamila and sadiya payments',
+            ['Sadiya Yusuf', 'Jamila Ahmed'],
+        );
+
+        assert.equal(text, 'please show Jamila and Sadiya payments');
+    });
+});


### PR DESCRIPTION
## Summary
- remove fuzzy Soundex/Levenshtein transcript rewrites that changed ordinary words into family member names
- keep only exact member-name token casing corrections for transcripts
- add a focused Node test covering the reported `standing`/`family` cases

## Validation
- node --test tests/Js/transcript-corrections.test.mjs
- npm run lint
- npm run format:check
- npm run build
- php artisan test --coverage --compact (`Total: 100.0 %`)