### PR TITLE
[codex] Support end-of-month contribution due dates

### DIFF
--- a/app/Actions/OnboardNgoFamily.php
+++ b/app/Actions/OnboardNgoFamily.php
@@ -147,7 +147,7 @@ class OnboardNgoFamily
     {
         $validator = Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
-            'due_day' => ['nullable', 'integer', 'min:1', 'max:28'],
+            'due_day' => ['nullable', 'integer', 'min:1', 'max:31'],
             'admin_name' => ['required', 'string', 'max:255'],
             'admin_email' => ['required', 'string', 'email', 'max:255', Rule::unique(User::class, 'email')],
             'admin_whatsapp' => ['required', 'string', 'regex:/^\+[1-9]\d{6,14}$/'],

--- a/app/Console/Commands/GenerateMonthlyContributions.php
+++ b/app/Console/Commands/GenerateMonthlyContributions.php
@@ -7,7 +7,6 @@ namespace App\Console\Commands;
 use App\Models\Contribution;
 use App\Models\Family;
 use App\Models\User;
-use Carbon\Carbon;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
@@ -34,7 +33,7 @@ class GenerateMonthlyContributions extends Command
         $month = (int) $monthOption;
         $familyId = $this->option('family');
 
-        $date = Carbon::createFromDate($year, $month, 1);
+        $date = Contribution::dueDateForMonth($year, $month, 1);
         $periodLabel = $date->format('F Y');
 
         $this->info("Generating contributions for {$periodLabel}...");
@@ -70,7 +69,7 @@ class GenerateMonthlyContributions extends Command
                 ], [
                     'family_id' => $family->id,
                     'expected_amount' => $member->getMonthlyAmount() ?? 0,
-                    'due_date' => Carbon::createFromDate($year, $month, min($dueDay, $date->daysInMonth)),
+                    'due_date' => Contribution::dueDateForMonth($year, $month, $dueDay),
                 ]);
 
                 if ($contribution->wasRecentlyCreated) {

--- a/app/Console/Commands/OnboardNgoFamily.php
+++ b/app/Console/Commands/OnboardNgoFamily.php
@@ -12,7 +12,7 @@ use Illuminate\Validation\ValidationException;
 
 #[Signature('ngo:onboard
     {--name= : NGO / organization name}
-    {--due-day=28 : Monthly contribution due day (1-28)}
+    {--due-day=28 : Monthly contribution due day (1-31, clamped to the last day of shorter months)}
     {--admin-name= : Admin full name}
     {--admin-email= : Admin email address}
     {--admin-whatsapp= : Admin WhatsApp number in international format, e.g. +97412345678}

--- a/app/Http/Controllers/FamilySettingsController.php
+++ b/app/Http/Controllers/FamilySettingsController.php
@@ -60,7 +60,7 @@ class FamilySettingsController extends Controller
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255'],
             'currency' => ['required', 'string', 'max:10'],
-            'due_day' => ['required', 'integer', 'min:1', 'max:28'],
+            'due_day' => ['required', 'integer', 'min:1', 'max:31'],
             'bank_name' => ['nullable', 'string', 'max:255'],
             'account_name' => ['nullable', 'string', 'max:255'],
             'account_number' => ['nullable', 'string', 'max:50'],

--- a/app/Models/Contribution.php
+++ b/app/Models/Contribution.php
@@ -43,6 +43,16 @@ class Contribution extends Model
     public const DUE_DAY = 28;
 
     /**
+     * Resolve the configured due day within the target month.
+     */
+    public static function dueDateForMonth(int $year, int $month, int $dueDay): Carbon
+    {
+        $date = Carbon::createFromDate($year, $month, 1);
+
+        return $date->setDay(max(1, min($dueDay, $date->daysInMonth)));
+    }
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var list<string>
@@ -241,7 +251,7 @@ class Contribution extends Model
             return Carbon::parse($dueDate);
         }
 
-        return Carbon::createFromDate($this->year, $this->month, self::DUE_DAY);
+        return self::dueDateForMonth($this->year, $this->month, self::DUE_DAY);
     }
 
     /**

--- a/app/Services/PaymentAllocationService.php
+++ b/app/Services/PaymentAllocationService.php
@@ -8,7 +8,6 @@ use App\Models\Contribution;
 use App\Models\Family;
 use App\Models\Payment;
 use App\Models\User;
-use Carbon\Carbon;
 use DateTimeInterface;
 use Illuminate\Support\Collection;
 
@@ -175,7 +174,7 @@ class PaymentAllocationService
             'year' => $year,
             'month' => $month,
             'expected_amount' => $member->getMonthlyAmount() ?? 0,
-            'due_date' => Carbon::createFromDate($year, $month, $dueDay),
+            'due_date' => Contribution::dueDateForMonth($year, $month, $dueDay),
         ]);
     }
 

--- a/resources/js/pages/Family/Settings.vue
+++ b/resources/js/pages/Family/Settings.vue
@@ -186,7 +186,7 @@ function cancelEdit(): void {
                                 type="number"
                                 :default-value="String(family.due_day)"
                                 min="1"
-                                max="28"
+                                max="31"
                                 required
                             />
                             <InputError :message="errors.due_day" />

--- a/tests/Browser/FinancialOperationsFlowTest.php
+++ b/tests/Browser/FinancialOperationsFlowTest.php
@@ -123,7 +123,7 @@ describe('Financial and family administration flows (Browser)', function () {
             ->assertSee('Family Settings')
             ->fill('name', 'Browser Updated Family')
             ->fill('currency', '₦')
-            ->fill('due_day', '15')
+            ->fill('due_day', '30')
             ->fill('account_name', 'Browser Account')
             ->fill('account_number', '1234567890')
             ->click('Save Changes')
@@ -138,7 +138,7 @@ describe('Financial and family administration flows (Browser)', function () {
         $this->family->refresh();
 
         expect($this->family->name)->toBe('Browser Updated Family')
-            ->and($this->family->due_day)->toBe(15)
+            ->and($this->family->due_day)->toBe(30)
             ->and(FamilyCategory::where('family_id', $this->family->id)
                 ->where('name', 'Browser Senior')
                 ->where('monthly_amount', 7500)

--- a/tests/Feature/Commands/NgoOnboardingTest.php
+++ b/tests/Feature/Commands/NgoOnboardingTest.php
@@ -50,7 +50,7 @@ it('onboards an ngo with qar monthly dues and privileged users', function () {
 
     $this->artisan('ngo:onboard', [
         '--name' => 'Qatar Helping Hands',
-        '--due-day' => '25',
+        '--due-day' => '30',
         '--admin-name' => 'Ngo Admin',
         '--admin-email' => 'admin@ngo.test',
         '--admin-whatsapp' => '+97455550001',
@@ -65,7 +65,7 @@ it('onboards an ngo with qar monthly dues and privileged users', function () {
     $financialSecretary = User::query()->where('email', 'finance@ngo.test')->firstOrFail();
 
     expect($family->currency)->toBe('QAR')
-        ->and($family->due_day)->toBe(25)
+        ->and($family->due_day)->toBe(30)
         ->and($family->created_by)->toBe($admin->id)
         ->and($category->name)->toBe('Monthly Dues')
         ->and($category->monthly_amount)->toBe(100)

--- a/tests/Feature/ContributionDueDateTest.php
+++ b/tests/Feature/ContributionDueDateTest.php
@@ -38,6 +38,12 @@ describe('Contribution Due Date', function () {
         expect($contribution->due_date->month)->toBe(2);
     });
 
+    it('clamps custom due dates to the last day of the target month', function () {
+        expect(Contribution::dueDateForMonth(2027, 2, 30)->toDateString())->toBe('2027-02-28')
+            ->and(Contribution::dueDateForMonth(2028, 2, 30)->toDateString())->toBe('2028-02-29')
+            ->and(Contribution::dueDateForMonth(2027, 4, 31)->toDateString())->toBe('2027-04-30');
+    });
+
     it('due_date works for different months', function () {
         $months = [
             ['month' => 3, 'name' => 'March'],

--- a/tests/Feature/FamilySettingsTest.php
+++ b/tests/Feature/FamilySettingsTest.php
@@ -87,6 +87,22 @@ it('updates family settings with bank code', function () {
         ->and($family->account_number)->toBe('0045502216');
 });
 
+it('allows family settings due day at the end of the month', function () {
+    $family = Family::factory()->create();
+    $admin = User::factory()->admin()->create(['family_id' => $family->id]);
+
+    $this->actingAs($admin)
+        ->put(route('family.settings.update'), [
+            'name' => $family->name,
+            'currency' => $family->currency,
+            'due_day' => 30,
+        ])
+        ->assertRedirect()
+        ->assertSessionHas('success', 'Family settings updated.');
+
+    expect($family->refresh()->due_day)->toBe(30);
+});
+
 it('dispatches paystack subaccount sync only when complete bank details change', function () {
     Queue::fake();
 

--- a/tests/Feature/GenerateContributionsTest.php
+++ b/tests/Feature/GenerateContributionsTest.php
@@ -171,6 +171,21 @@ describe('Generate Monthly Contributions Command', function () {
         expect($contribution->due_date->day)->toBe(15);
     });
 
+    it('clamps family due day to the last day of shorter months', function () {
+        $family = Family::factory()->create(['due_day' => 30]);
+        User::factory()->member()->employed()->create(['family_id' => $family->id]);
+
+        $this->artisan('contributions:generate', [
+            '--family' => $family->id,
+            '--year' => 2027,
+            '--month' => 2,
+        ])->assertSuccessful();
+
+        $contribution = Contribution::where('family_id', $family->id)->firstOrFail();
+
+        expect($contribution->due_date->toDateString())->toBe('2027-02-28');
+    });
+
     it('generates for all families when no family specified', function () {
         $family1 = Family::factory()->create();
         $family2 = Family::factory()->create();

--- a/tests/Feature/Payments/BalanceFirstRuleTest.php
+++ b/tests/Feature/Payments/BalanceFirstRuleTest.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 use App\Enums\PaymentStatus;
 use App\Models\Contribution;
+use App\Models\Family;
 use App\Models\Payment;
 use App\Models\User;
+use Carbon\Carbon;
+
+afterEach(function () {
+    Carbon::setTestNow();
+});
 
 /**
  * FR-020: Balance-First Rule
@@ -207,5 +213,29 @@ describe('Balance-First Rule (FR-020)', function () {
             ->firstOrFail();
 
         expect($contribution->status)->toBe(PaymentStatus::Paid);
+    });
+
+    it('clamps created target month contribution due date for February', function () {
+        Carbon::setTestNow(Carbon::create(2027, 1, 15, 12));
+
+        $family = Family::factory()->create(['due_day' => 30]);
+        $this->financialSecretary->update(['family_id' => $family->id]);
+        $this->member->update(['family_id' => $family->id]);
+
+        $this->actingAs($this->financialSecretary)
+            ->post(route('payments.store'), [
+                'member_id' => $this->member->id,
+                'amount' => 4000,
+                'paid_at' => now()->toDateString(),
+                'target_year' => 2027,
+                'target_month' => 2,
+            ])
+            ->assertRedirect();
+
+        $contribution = Contribution::forUser($this->member->id)
+            ->forMonth(2027, 2)
+            ->firstOrFail();
+
+        expect($contribution->due_date->toDateString())->toBe('2027-02-28');
     });
 });


### PR DESCRIPTION
## Summary
- allow NGO/family due days through the end of the month instead of capping at 28
- clamp generated contribution due dates to the last valid day for shorter months, including February
- cover onboarding, contribution generation, payment-created contributions, and family settings with focused tests

## Validation
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/Commands/NgoOnboardingTest.php tests/Feature/ContributionDueDateTest.php tests/Feature/GenerateContributionsTest.php tests/Feature/Payments/BalanceFirstRuleTest.php tests/Feature/FamilySettingsTest.php
- composer analyse
- git diff --check