### PR TITLE
[codex] Allow financial secretaries to add members

### DIFF
--- a/app/Ai/Tools/SendInvitation.php
+++ b/app/Ai/Tools/SendInvitation.php
@@ -29,7 +29,7 @@ class SendInvitation implements Tool
      */
     public function description(): string
     {
-        return 'Sends an invitation to join the family group via email or WhatsApp. Requires delivery_method=email with email, or delivery_method=whatsapp with whatsapp_phone, plus role (admin, financial_secretary, or member). Only admins can send invitations. Always call without confirmed=true first to preview.';
+        return 'Sends an invitation to join the family group via email or WhatsApp. Requires delivery_method=email with email, or delivery_method=whatsapp with whatsapp_phone, plus role (admin, financial_secretary, or member). Admins can invite any role; financial secretaries can invite members. Always call without confirmed=true first to preview.';
     }
 
     /**
@@ -37,8 +37,8 @@ class SendInvitation implements Tool
      */
     public function handle(Request $request): string
     {
-        if (! $this->user->isAdmin()) {
-            return json_encode(['error' => 'Only family admins can send invitations.'], JSON_THROW_ON_ERROR);
+        if (! $this->user->canAddMembers()) {
+            return json_encode(['error' => 'Only family admins and financial secretaries can send invitations.'], JSON_THROW_ON_ERROR);
         }
 
         $deliveryMethodValue = $this->stringFromRequest($request['delivery_method'] ?? null, InvitationDeliveryMethod::Email->value);
@@ -78,6 +78,10 @@ class SendInvitation implements Tool
 
         if (! $role) {
             return json_encode(['error' => "Invalid role \"{$roleValue}\". Choose from: admin, financial_secretary, or member."], JSON_THROW_ON_ERROR);
+        }
+
+        if (! $this->user->canManageRoles() && $role !== Role::Member) {
+            return json_encode(['error' => 'Only family admins can invite admin or financial secretary roles.'], JSON_THROW_ON_ERROR);
         }
 
         $existingMemberQuery = User::query()->where('family_id', $this->user->family_id);

--- a/app/Enums/Role.php
+++ b/app/Enums/Role.php
@@ -39,6 +39,14 @@ enum Role: string
     }
 
     /**
+     * Check if this role can add or invite ordinary members.
+     */
+    public function canAddMembers(): bool
+    {
+        return $this !== self::Member;
+    }
+
+    /**
      * Check if this role can manage roles.
      */
     public function canManageRoles(): bool

--- a/app/Http/Controllers/InvitationController.php
+++ b/app/Http/Controllers/InvitationController.php
@@ -29,7 +29,7 @@ class InvitationController extends Controller
     {
         $user = $this->authUser();
 
-        if (! $user->isAdmin()) {
+        if (! $user->canAddMembers()) {
             abort(403);
         }
 
@@ -60,6 +60,7 @@ class InvitationController extends Controller
         return Inertia::render('Family/Invitations', [
             'invitations' => $invitations,
             'family_name' => $family instanceof Family ? $family->name : 'the family',
+            'roles' => $this->getRoleOptions($user),
         ]);
     }
 
@@ -67,7 +68,7 @@ class InvitationController extends Controller
     {
         $user = $this->authUser();
 
-        if (! $user->isAdmin()) {
+        if (! $user->canAddMembers()) {
             abort(403);
         }
 
@@ -86,6 +87,12 @@ class InvitationController extends Controller
             'whatsapp_phone.regex' => 'Enter a valid WhatsApp number in international format (e.g. +2348012345678).',
         ]);
         $attributes = $this->invitationAttributes($validated);
+
+        if (! $user->canManageRoles() && $attributes['role'] !== Role::Member) {
+            return redirect()->back()->withErrors([
+                'role' => 'Only family admins can invite admin or financial secretary roles.',
+            ])->withInput();
+        }
 
         $deliveryMethod = $attributes['delivery_method'];
         $email = $attributes['email'];
@@ -163,7 +170,7 @@ class InvitationController extends Controller
     {
         $user = $this->authUser();
 
-        if (! $user->isAdmin() || $invitation->family_id !== $user->family_id) {
+        if (! $user->canAddMembers() || $invitation->family_id !== $user->family_id) {
             abort(403);
         }
 
@@ -225,6 +232,26 @@ class InvitationController extends Controller
     private function nullableString(mixed $value): ?string
     {
         return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    /**
+     * Get role options for invitation forms.
+     *
+     * @return array<int, array{value: string, label: string}>
+     */
+    private function getRoleOptions(User $user): array
+    {
+        $roles = $user->canManageRoles()
+            ? Role::cases()
+            : [Role::Member];
+
+        return array_map(
+            fn (Role $role): array => [
+                'value' => $role->value,
+                'label' => $role->label(),
+            ],
+            $roles,
+        );
     }
 
     /**

--- a/app/Http/Controllers/InvitationController.php
+++ b/app/Http/Controllers/InvitationController.php
@@ -53,6 +53,7 @@ class InvitationController extends Controller
                 'is_accepted' => $invitation->isAccepted(),
                 'is_expired' => $invitation->isExpired(),
                 'is_pending' => $invitation->isPending(),
+                'can_cancel' => $this->canCancelInvitation($user, $invitation),
                 'expires_at' => $invitation->expires_at->toDateString(),
                 'created_at' => $invitation->created_at?->toDateString(),
             ]);
@@ -170,7 +171,11 @@ class InvitationController extends Controller
     {
         $user = $this->authUser();
 
-        if (! $user->canAddMembers() || $invitation->family_id !== $user->family_id) {
+        if (
+            ! $user->canAddMembers()
+            || $invitation->family_id !== $user->family_id
+            || ! $this->canCancelInvitation($user, $invitation)
+        ) {
             abort(403);
         }
 
@@ -232,6 +237,11 @@ class InvitationController extends Controller
     private function nullableString(mixed $value): ?string
     {
         return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    private function canCancelInvitation(User $user, FamilyInvitation $invitation): bool
+    {
+        return $user->canManageRoles() || $invitation->role === Role::Member;
     }
 
     /**

--- a/app/Http/Controllers/MemberController.php
+++ b/app/Http/Controllers/MemberController.php
@@ -64,31 +64,32 @@ class MemberController extends Controller
         return Inertia::render('Members/Index', [
             'members' => $members,
             'archivedMembers' => $archivedMembers,
+            'canAddMembers' => $currentUser->canAddMembers(),
             'canManageMembers' => $currentUser->canManageMembers(),
         ]);
     }
 
     /**
      * Show the form for creating a new family member.
-     * Only Admin can access.
+     * Admin and Financial Secretary can access.
      */
     public function create(): Response
     {
         $user = $this->authUser();
 
-        if (! $user->canManageMembers()) {
+        if (! $user->canAddMembers()) {
             abort(403);
         }
 
         return Inertia::render('Members/Create', [
             'categories' => $this->getCategoryOptions(),
-            'roles' => $this->getRoleOptions(),
+            'roles' => $this->getRoleOptions($user),
         ]);
     }
 
     /**
      * Store a newly created family member.
-     * Only Admin can create members.
+     * Admin and Financial Secretary can create ordinary members.
      */
     public function store(StoreMemberRequest $request): RedirectResponse
     {
@@ -350,14 +351,18 @@ class MemberController extends Controller
      *
      * @return array<int, array{value: string, label: string}>
      */
-    private function getRoleOptions(): array
+    private function getRoleOptions(?User $user = null): array
     {
+        $roles = $user instanceof User && ! $user->canManageRoles()
+            ? [Role::Member]
+            : Role::cases();
+
         return array_map(
             fn (Role $role): array => [
                 'value' => $role->value,
                 'label' => $role->label(),
             ],
-            Role::cases(),
+            $roles,
         );
     }
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -59,6 +59,7 @@ class HandleInertiaRequests extends Middleware
                     'whatsapp_verified_at' => $user->whatsapp_verified_at,
                 ] : null,
                 'can' => $user ? [
+                    'add_members' => $user->role->canAddMembers(),
                     'manage_members' => $user->role->canManageMembers(),
                     'record_payments' => $user->role->canRecordPayments(),
                     'generate_reports' => $user->role->canGenerateReports(),

--- a/app/Http/Requests/StoreMemberRequest.php
+++ b/app/Http/Requests/StoreMemberRequest.php
@@ -6,10 +6,12 @@ namespace App\Http\Requests;
 
 use App\Enums\MemberCategory;
 use App\Enums\Role;
+use App\Models\User;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\Validator;
 
 class StoreMemberRequest extends FormRequest
 {
@@ -18,7 +20,9 @@ class StoreMemberRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return $this->user()?->canManageMembers() ?? false;
+        $user = $this->user();
+
+        return $user instanceof User && $user->canAddMembers();
     }
 
     /**
@@ -35,6 +39,24 @@ class StoreMemberRequest extends FormRequest
             'category' => ['required', new Enum(MemberCategory::class)],
             'role' => ['required', new Enum(Role::class)],
         ];
+    }
+
+    /**
+     * Configure the validator instance.
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $user = $this->user();
+
+            if (! $user instanceof User || $user->canManageRoles()) {
+                return;
+            }
+
+            if ($this->input('role') !== Role::Member->value) {
+                $validator->errors()->add('role', 'Only family admins can assign admin or financial secretary roles.');
+            }
+        });
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -315,6 +315,22 @@ class User extends Authenticatable implements MustVerifyEmail, OAuthenticatable,
     }
 
     /**
+     * Check if user can add or invite ordinary members.
+     */
+    public function canAddMembers(): bool
+    {
+        return $this->role->canAddMembers();
+    }
+
+    /**
+     * Check if user can assign privileged roles.
+     */
+    public function canManageRoles(): bool
+    {
+        return $this->role->canManageRoles();
+    }
+
+    /**
      * Check if user can view all members' details.
      */
     public function canViewAllMembers(): bool

--- a/resources/js/lib/appNavigation.ts
+++ b/resources/js/lib/appNavigation.ts
@@ -185,33 +185,41 @@ export function useAppNavigation() {
     });
 
     const adminItems = computed<NavItem[]>(() => {
-        if (page.props.auth?.user?.role !== 'admin') {
-            return [];
-        }
+        const isAdmin = page.props.auth?.user?.role === 'admin';
+        const canAddMembers = page.props.auth?.can?.add_members === true;
+        const items: NavItem[] = [];
 
-        return [
-            {
+        if (isAdmin) {
+            items.push({
                 title: 'Family Settings',
                 href: familySettings(),
                 icon: Settings,
                 component: 'Family/Settings',
                 section: 'Family Admin',
-            },
-            {
+            });
+        }
+
+        if (canAddMembers) {
+            items.push({
                 title: 'Invitations',
                 href: invitationsIndex(),
                 icon: Mail,
                 component: 'Family/Invitations',
                 section: 'Family Admin',
-            },
-            {
+            });
+        }
+
+        if (isAdmin) {
+            items.push({
                 title: 'Subscription',
                 href: subscriptionIndex(),
                 icon: Sparkles,
                 component: 'Subscription/Index',
                 section: 'Family Admin',
-            },
-        ];
+            });
+        }
+
+        return items;
     });
 
     const platformItems = computed<NavItem[]>(() => {

--- a/resources/js/pages/Family/Invitations.vue
+++ b/resources/js/pages/Family/Invitations.vue
@@ -42,6 +42,7 @@ interface Invitation {
     is_accepted: boolean;
     is_expired: boolean;
     is_pending: boolean;
+    can_cancel: boolean;
     expires_at: string;
     created_at: string;
 }
@@ -305,7 +306,9 @@ function statusBadge(invitation: Invitation): { text: string; class: string } {
                             {{ statusBadge(invitation).text }}
                         </span>
                         <Button
-                            v-if="invitation.is_pending"
+                            v-if="
+                                invitation.is_pending && invitation.can_cancel
+                            "
                             variant="ghost"
                             size="icon"
                             class="text-destructive hover:text-destructive"

--- a/resources/js/pages/Family/Invitations.vue
+++ b/resources/js/pages/Family/Invitations.vue
@@ -49,11 +49,13 @@ interface Invitation {
 interface Props {
     invitations?: Invitation[];
     family_name?: string;
+    roles?: Array<{ value: string; label: string }>;
 }
 
 const props = withDefaults(defineProps<Props>(), {
     invitations: () => [],
     family_name: '',
+    roles: () => [],
 });
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -237,11 +239,13 @@ function statusBadge(invitation: Invitation): { text: string; class: string } {
                             class="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
                             required
                         >
-                            <option value="member">Member</option>
-                            <option value="financial_secretary">
-                                Financial Secretary
+                            <option
+                                v-for="role in props.roles"
+                                :key="role.value"
+                                :value="role.value"
+                            >
+                                {{ role.label }}
                             </option>
-                            <option value="admin">Admin</option>
                         </select>
                         <InputError :message="errors.role" />
                     </div>

--- a/resources/js/pages/Members/Index.vue
+++ b/resources/js/pages/Members/Index.vue
@@ -34,12 +34,14 @@ interface Member {
 interface Props {
     members?: Member[];
     archivedMembers?: Member[];
+    canAddMembers?: boolean;
     canManageMembers?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
     members: () => [],
     archivedMembers: () => [],
+    canAddMembers: false,
     canManageMembers: false,
 });
 
@@ -100,7 +102,7 @@ function formatCurrency(amount: number): string {
                         }}</span>
                     </Button>
                     <Link
-                        v-if="canManageMembers && canAddMore"
+                        v-if="canAddMembers && canAddMore"
                         :href="create().url"
                     >
                         <Button size="sm">
@@ -113,7 +115,7 @@ function formatCurrency(amount: number): string {
 
             <!-- Member limit banner -->
             <div
-                v-if="canManageMembers && !canAddMore"
+                v-if="canAddMembers && !canAddMore"
                 class="flex items-center justify-between rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800 dark:bg-amber-950"
             >
                 <p class="text-sm text-amber-800 dark:text-amber-200">

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -7,6 +7,7 @@ export interface Auth {
 }
 
 export interface Permissions {
+    add_members: boolean;
     manage_members: boolean;
     record_payments: boolean;
     generate_reports: boolean;

--- a/tests/Browser/FinancialOperationsFlowTest.php
+++ b/tests/Browser/FinancialOperationsFlowTest.php
@@ -99,13 +99,13 @@ describe('Financial and family administration flows (Browser)', function () {
     it('sends a family invitation through the UI', function () {
         Mail::fake();
 
-        $page = loginBrowserAs($this->admin);
+        $page = loginBrowserAs($this->financialSecretary);
 
         $page->navigate(route('family.invitations'))
             ->assertSee('Invitations')
             ->click('Invite Member')
             ->fill('email', 'browser-invite@example.com')
-            ->select('role', 'financial_secretary')
+            ->select('role', 'member')
             ->click('Send Invitation')
             ->assertSee('browser-invite@example.com')
             ->assertSee('Pending')
@@ -113,6 +113,7 @@ describe('Financial and family administration flows (Browser)', function () {
 
         expect(FamilyInvitation::where('family_id', $this->family->id)
             ->where('email', 'browser-invite@example.com')
+            ->where('invited_by', $this->financialSecretary->id)
             ->exists())->toBeTrue();
     });
 

--- a/tests/Browser/MemberManagementFlowTest.php
+++ b/tests/Browser/MemberManagementFlowTest.php
@@ -177,7 +177,7 @@ describe('Member Management Flow (Browser)', function () {
             ->assertSee('403');
     });
 
-    it('financial secretary cannot access create member page', function () {
+    it('financial secretary can access create member page', function () {
         $fs = createBrowserFinancialSecretary($this->family, [
             'email' => 'fs@test.com',
         ]);
@@ -185,6 +185,7 @@ describe('Member Management Flow (Browser)', function () {
         $page = loginBrowserAs($fs);
 
         $page->navigate('/members/create')
-            ->assertSee('403');
+            ->assertSee('Add New Member')
+            ->assertNoJavaScriptErrors();
     });
 });

--- a/tests/Feature/Ai/Tools/SendInvitationTest.php
+++ b/tests/Feature/Ai/Tools/SendInvitationTest.php
@@ -93,15 +93,39 @@ test('admin can execute invitation sending over whatsapp', function () {
     ]);
 });
 
-test('financial secretary cannot send invitations', function () {
+test('financial secretary can execute member invitation sending', function () {
+    Mail::fake();
+
     $tool = new SendInvitation($this->financialSecretary);
 
     $result = decodeToolResult($tool->handle(new Request([
         'email' => 'newmember@example.com',
         'role' => 'member',
+        'confirmed' => true,
     ])));
 
-    expect($result['error'])->toContain('Only family admins');
+    expect($result['status'])->toBe('success')
+        ->and($result['message'])->toContain('newmember@example.com');
+
+    $this->assertDatabaseHas('family_invitations', [
+        'family_id' => $this->family->id,
+        'email' => 'newmember@example.com',
+        'invited_by' => $this->financialSecretary->id,
+    ]);
+
+    Mail::assertQueued(FamilyInvitationMail::class);
+});
+
+test('financial secretary cannot invite privileged roles', function () {
+    $tool = new SendInvitation($this->financialSecretary);
+
+    $result = decodeToolResult($tool->handle(new Request([
+        'email' => 'newadmin@example.com',
+        'role' => 'admin',
+        'confirmed' => true,
+    ])));
+
+    expect($result['error'])->toContain('Only family admins can invite admin or financial secretary roles');
 });
 
 test('member cannot send invitations', function () {
@@ -112,7 +136,7 @@ test('member cannot send invitations', function () {
         'role' => 'member',
     ])));
 
-    expect($result['error'])->toContain('Only family admins');
+    expect($result['error'])->toContain('Only family admins and financial secretaries');
 });
 
 test('invitation rejects invalid email', function () {

--- a/tests/Feature/InvitationTest.php
+++ b/tests/Feature/InvitationTest.php
@@ -103,6 +103,43 @@ describe('Invitation Store', function () {
         expect(FamilyInvitation::where('email', 'new@example.com')->count())->toBe(1);
     });
 
+    it('allows financial secretaries to invite ordinary members', function () {
+        $family = Family::factory()->create();
+        $financialSecretary = User::factory()->financialSecretary()->create(['family_id' => $family->id]);
+
+        $this->actingAs($financialSecretary)
+            ->post('/family/invitations', [
+                'email' => 'new@example.com',
+                'role' => Role::Member->value,
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        $this->assertDatabaseHas('family_invitations', [
+            'family_id' => $family->id,
+            'email' => 'new@example.com',
+            'role' => Role::Member->value,
+            'invited_by' => $financialSecretary->id,
+        ]);
+    });
+
+    it('prevents financial secretaries from inviting privileged roles', function () {
+        $family = Family::factory()->create();
+        $financialSecretary = User::factory()->financialSecretary()->create(['family_id' => $family->id]);
+
+        $this->actingAs($financialSecretary)
+            ->post('/family/invitations', [
+                'email' => 'new-admin@example.com',
+                'role' => Role::Admin->value,
+            ])
+            ->assertRedirect()
+            ->assertSessionHasErrors('role');
+
+        $this->assertDatabaseMissing('family_invitations', [
+            'email' => 'new-admin@example.com',
+        ]);
+    });
+
     it('allows inviting a new whatsapp number', function () {
         config()->set('services.whatsapp', [
             'access_token' => 'test-token',
@@ -234,7 +271,7 @@ describe('Invitation Store', function () {
         expect(FamilyInvitation::where('whatsapp_phone', '+2348012345678')->exists())->toBeFalse();
     });
 
-    it('prevents non-admin from sending invitations', function () {
+    it('prevents members from sending invitations', function () {
         $family = Family::factory()->create();
         $member = User::factory()->member()->create(['family_id' => $family->id]);
 
@@ -282,10 +319,38 @@ describe('Invitation Index', function () {
                 ->where('invitations.0.role_label', 'Financial Secretary')
                 ->where('invitations.0.invited_by', 'Ada Admin')
                 ->where('invitations.0.is_pending', true)
+                ->has('roles', 3)
+                ->where('roles.0.value', Role::Admin->value)
+                ->where('roles.1.value', Role::FinancialSecretary->value)
+                ->where('roles.2.value', Role::Member->value)
             );
     });
 
-    it('prevents non-admins from listing invitations', function () {
+    it('lists family invitations for financial secretaries', function () {
+        $family = Family::factory()->create(['name' => 'Smith Family']);
+        $financialSecretary = User::factory()->financialSecretary()->create(['family_id' => $family->id]);
+
+        FamilyInvitation::factory()->create([
+            'family_id' => $family->id,
+            'email' => 'first@example.com',
+            'role' => Role::Member,
+            'expires_at' => now()->addDays(7),
+        ]);
+
+        $this->actingAs($financialSecretary)
+            ->get(route('family.invitations'))
+            ->assertSuccessful()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Family/Invitations')
+                ->where('family_name', 'Smith Family')
+                ->has('invitations', 1)
+                ->where('invitations.0.email', 'first@example.com')
+                ->has('roles', 1)
+                ->where('roles.0.value', Role::Member->value)
+            );
+    });
+
+    it('prevents members from listing invitations', function () {
         $member = User::factory()->member()->create();
 
         $this->actingAs($member)
@@ -308,6 +373,19 @@ describe('Invitation Destroy', function () {
         expect(FamilyInvitation::whereKey($invitation->id)->exists())->toBeFalse();
     });
 
+    it('allows financial secretaries to cancel invitations in their family', function () {
+        $family = Family::factory()->create();
+        $financialSecretary = User::factory()->financialSecretary()->create(['family_id' => $family->id]);
+        $invitation = FamilyInvitation::factory()->create(['family_id' => $family->id]);
+
+        $this->actingAs($financialSecretary)
+            ->delete(route('family.invitations.destroy', $invitation))
+            ->assertRedirect()
+            ->assertSessionHas('success', 'Invitation cancelled.');
+
+        expect(FamilyInvitation::whereKey($invitation->id)->exists())->toBeFalse();
+    });
+
     it('prevents admins from cancelling invitations in another family', function () {
         $admin = User::factory()->admin()->create();
         $invitation = FamilyInvitation::factory()->create();
@@ -317,7 +395,7 @@ describe('Invitation Destroy', function () {
             ->assertForbidden();
     });
 
-    it('prevents non-admins from cancelling invitations', function () {
+    it('prevents members from cancelling invitations', function () {
         $family = Family::factory()->create();
         $member = User::factory()->member()->create(['family_id' => $family->id]);
         $invitation = FamilyInvitation::factory()->create(['family_id' => $family->id]);

--- a/tests/Feature/InvitationTest.php
+++ b/tests/Feature/InvitationTest.php
@@ -319,6 +319,7 @@ describe('Invitation Index', function () {
                 ->where('invitations.0.role_label', 'Financial Secretary')
                 ->where('invitations.0.invited_by', 'Ada Admin')
                 ->where('invitations.0.is_pending', true)
+                ->where('invitations.0.can_cancel', true)
                 ->has('roles', 3)
                 ->where('roles.0.value', Role::Admin->value)
                 ->where('roles.1.value', Role::FinancialSecretary->value)
@@ -335,6 +336,14 @@ describe('Invitation Index', function () {
             'email' => 'first@example.com',
             'role' => Role::Member,
             'expires_at' => now()->addDays(7),
+            'created_at' => now(),
+        ]);
+        FamilyInvitation::factory()->create([
+            'family_id' => $family->id,
+            'email' => 'admin@example.com',
+            'role' => Role::Admin,
+            'expires_at' => now()->addDays(7),
+            'created_at' => now()->subMinute(),
         ]);
 
         $this->actingAs($financialSecretary)
@@ -343,8 +352,11 @@ describe('Invitation Index', function () {
             ->assertInertia(fn (Assert $page) => $page
                 ->component('Family/Invitations')
                 ->where('family_name', 'Smith Family')
-                ->has('invitations', 1)
+                ->has('invitations', 2)
                 ->where('invitations.0.email', 'first@example.com')
+                ->where('invitations.0.can_cancel', true)
+                ->where('invitations.1.email', 'admin@example.com')
+                ->where('invitations.1.can_cancel', false)
                 ->has('roles', 1)
                 ->where('roles.0.value', Role::Member->value)
             );
@@ -363,7 +375,10 @@ describe('Invitation Destroy', function () {
     it('allows admins to cancel invitations in their family', function () {
         $family = Family::factory()->create();
         $admin = User::factory()->admin()->create(['family_id' => $family->id]);
-        $invitation = FamilyInvitation::factory()->create(['family_id' => $family->id]);
+        $invitation = FamilyInvitation::factory()->create([
+            'family_id' => $family->id,
+            'role' => Role::Admin,
+        ]);
 
         $this->actingAs($admin)
             ->delete(route('family.invitations.destroy', $invitation))
@@ -373,10 +388,13 @@ describe('Invitation Destroy', function () {
         expect(FamilyInvitation::whereKey($invitation->id)->exists())->toBeFalse();
     });
 
-    it('allows financial secretaries to cancel invitations in their family', function () {
+    it('allows financial secretaries to cancel member invitations in their family', function () {
         $family = Family::factory()->create();
         $financialSecretary = User::factory()->financialSecretary()->create(['family_id' => $family->id]);
-        $invitation = FamilyInvitation::factory()->create(['family_id' => $family->id]);
+        $invitation = FamilyInvitation::factory()->create([
+            'family_id' => $family->id,
+            'role' => Role::Member,
+        ]);
 
         $this->actingAs($financialSecretary)
             ->delete(route('family.invitations.destroy', $invitation))
@@ -384,6 +402,21 @@ describe('Invitation Destroy', function () {
             ->assertSessionHas('success', 'Invitation cancelled.');
 
         expect(FamilyInvitation::whereKey($invitation->id)->exists())->toBeFalse();
+    });
+
+    it('prevents financial secretaries from cancelling privileged invitations', function () {
+        $family = Family::factory()->create();
+        $financialSecretary = User::factory()->financialSecretary()->create(['family_id' => $family->id]);
+        $invitation = FamilyInvitation::factory()->create([
+            'family_id' => $family->id,
+            'role' => Role::Admin,
+        ]);
+
+        $this->actingAs($financialSecretary)
+            ->delete(route('family.invitations.destroy', $invitation))
+            ->assertForbidden();
+
+        expect(FamilyInvitation::whereKey($invitation->id)->exists())->toBeTrue();
     });
 
     it('prevents admins from cancelling invitations in another family', function () {

--- a/tests/Feature/Members/MemberAuthorizationTest.php
+++ b/tests/Feature/Members/MemberAuthorizationTest.php
@@ -94,17 +94,22 @@ describe('Member Authorization', function () {
             );
     });
 
-    // Create - Only Admin
+    // Create - Admin and Financial Secretary can add ordinary members
     it('super admin can access create form', function () {
         $this->actingAs($this->admin)
             ->get('/members/create')
             ->assertOk();
     });
 
-    it('financial secretary cannot access create form', function () {
+    it('financial secretary can access create form with only member role available', function () {
         $this->actingAs($this->financialSecretary)
             ->get('/members/create')
-            ->assertForbidden();
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Members/Create')
+                ->has('roles', 1)
+                ->where('roles.0.value', 'member')
+            );
     });
 
     it('member cannot access create form', function () {
@@ -113,7 +118,7 @@ describe('Member Authorization', function () {
             ->assertForbidden();
     });
 
-    // Store - Only Admin
+    // Store - Admin and Financial Secretary can add ordinary members
     it('super admin can create member', function () {
         $this->actingAs($this->admin)
             ->post('/members', [
@@ -129,7 +134,7 @@ describe('Member Authorization', function () {
         $this->assertDatabaseHas('users', ['email' => 'new@example.com']);
     });
 
-    it('financial secretary cannot create member', function () {
+    it('financial secretary can create ordinary member', function () {
         $this->actingAs($this->financialSecretary)
             ->post('/members', [
                 'name' => 'New Member',
@@ -139,9 +144,27 @@ describe('Member Authorization', function () {
                 'category' => 'employed',
                 'role' => 'member',
             ])
-            ->assertForbidden();
+            ->assertRedirect();
 
-        $this->assertDatabaseMissing('users', ['email' => 'new@example.com']);
+        $this->assertDatabaseHas('users', [
+            'email' => 'new@example.com',
+            'role' => 'member',
+        ]);
+    });
+
+    it('financial secretary cannot create privileged member', function () {
+        $this->actingAs($this->financialSecretary)
+            ->post('/members', [
+                'name' => 'New Admin',
+                'email' => 'new-admin@example.com',
+                'password' => 'password123',
+                'password_confirmation' => 'password123',
+                'category' => 'employed',
+                'role' => 'admin',
+            ])
+            ->assertSessionHasErrors('role');
+
+        $this->assertDatabaseMissing('users', ['email' => 'new-admin@example.com']);
     });
 
     it('member cannot create member', function () {

--- a/tests/Feature/Middleware/HandleInertiaRequestsTest.php
+++ b/tests/Feature/Middleware/HandleInertiaRequestsTest.php
@@ -46,6 +46,30 @@ test('flash returns null when session is not available', function () {
     expect($warning())->toBeNull();
 });
 
+test('share exposes add member permission for financial secretaries', function () {
+    $financialSecretary = User::factory()->financialSecretary()->create();
+
+    $this->actingAs($financialSecretary)
+        ->get(route('members.index'))
+        ->assertSuccessful()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('auth.can.add_members', true)
+            ->where('auth.can.manage_members', false)
+        );
+});
+
+test('share hides add member permission from ordinary members', function () {
+    $member = User::factory()->member()->create();
+
+    $this->actingAs($member)
+        ->get(route('members.index'))
+        ->assertSuccessful()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('auth.can.add_members', false)
+            ->where('auth.can.manage_members', false)
+        );
+});
+
 test('subscription data falls back when a user has no family', function () {
     $middleware = new HandleInertiaRequests;
     $method = (new ReflectionClass($middleware))->getMethod('subscriptionData');

--- a/tests/Feature/Models/UserTest.php
+++ b/tests/Feature/Models/UserTest.php
@@ -56,8 +56,13 @@ it('reports role helpers and monthly amounts', function () {
 
     expect($admin->isSuperAdmin())->toBeTrue()
         ->and($admin->isAdmin())->toBeTrue()
+        ->and($admin->canAddMembers())->toBeTrue()
         ->and($admin->canManageMembers())->toBeTrue()
+        ->and($admin->canManageRoles())->toBeTrue()
         ->and($financialSecretary->isFinancialSecretary())->toBeTrue()
+        ->and($financialSecretary->canAddMembers())->toBeTrue()
+        ->and($financialSecretary->canManageMembers())->toBeFalse()
+        ->and($financialSecretary->canManageRoles())->toBeFalse()
         ->and($financialSecretary->canViewAllMembers())->toBeTrue()
         ->and($member->isMember())->toBeTrue()
         ->and($member->getMonthlyAmount())->toBe(7500)

--- a/tests/Unit/Enums/RoleTest.php
+++ b/tests/Unit/Enums/RoleTest.php
@@ -8,6 +8,7 @@ it('exposes role labels and permissions', function (
     Role $role,
     string $label,
     bool $canRecordPayments,
+    bool $canAddMembers,
     bool $canManageMembers,
     bool $canManageRoles,
     bool $canViewAllMembers,
@@ -15,12 +16,13 @@ it('exposes role labels and permissions', function (
 ) {
     expect($role->label())->toBe($label)
         ->and($role->canRecordPayments())->toBe($canRecordPayments)
+        ->and($role->canAddMembers())->toBe($canAddMembers)
         ->and($role->canManageMembers())->toBe($canManageMembers)
         ->and($role->canManageRoles())->toBe($canManageRoles)
         ->and($role->canViewAllMembers())->toBe($canViewAllMembers)
         ->and($role->canGenerateReports())->toBe($canGenerateReports);
 })->with([
-    'admin' => [Role::Admin, 'Admin', true, true, true, true, true],
-    'financial secretary' => [Role::FinancialSecretary, 'Financial Secretary', true, false, false, true, true],
-    'member' => [Role::Member, 'Member', false, false, false, false, false],
+    'admin' => [Role::Admin, 'Admin', true, true, true, true, true, true],
+    'financial secretary' => [Role::FinancialSecretary, 'Financial Secretary', true, true, false, false, true, true],
+    'member' => [Role::Member, 'Member', false, false, false, false, false, false],
 ]);


### PR DESCRIPTION
## Summary
- allow financial secretaries to access member creation and family invitations
- keep role management, editing, archiving, restore, settings, and subscription controls admin-only
- limit financial secretaries to ordinary member role options in add/invite flows, including the AI invitation tool

## Validation
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Unit/Enums/RoleTest.php tests/Feature/Models/UserTest.php tests/Feature/InvitationTest.php tests/Feature/Ai/Tools/SendInvitationTest.php tests/Feature/Members/MemberAuthorizationTest.php tests/Feature/Middleware/HandleInertiaRequestsTest.php
- php artisan test --compact tests/Browser/MemberManagementFlowTest.php --filter='financial secretary can access create member page'
- php artisan test --compact tests/Browser/FinancialOperationsFlowTest.php --filter='sends a family invitation through the UI'
- npm run format:check
- npm run lint
- npm run build
- composer analyse
- git diff --check

Note: npm run build completed successfully with existing Rolldown INVALID_ANNOTATION warnings from node_modules/reka-ui/@vueuse.