### PR TITLE
[codex] Respect family currency in contribution UI

### DIFF
--- a/app/Ai/Agents/FamilyAssistant.php
+++ b/app/Ai/Agents/FamilyAssistant.php
@@ -84,7 +84,7 @@ class FamilyAssistant implements Agent, Conversational, HasMiddleware, HasProvid
         - NEVER set confirmed=true on the first call. Always preview first.
 
         Guidelines:
-        - All monetary values are in {$currency} (Nigerian Naira).
+        - All monetary values are in {$currency}.
         - Use the available sub-agents to fetch real-time data before answering financial questions.
         - Each sub-agent runs in isolation and does not receive this parent conversation history, so every delegated task must be clear and self-contained.
         - Include the user's role, family context, period, requested action details, and confirmation status when delegating.

--- a/app/Ai/Tools/GetMemberOverview.php
+++ b/app/Ai/Tools/GetMemberOverview.php
@@ -31,7 +31,7 @@ class GetMemberOverview implements Tool
         $members = User::query()
             ->where('family_id', $this->user->family_id)
             ->active()
-            ->with('familyCategory:id,name')
+            ->with('familyCategory:id,name,monthly_amount')
             ->orderBy('name')
             ->get();
 

--- a/app/Ai/Tools/RecordExpense.php
+++ b/app/Ai/Tools/RecordExpense.php
@@ -7,6 +7,7 @@ namespace App\Ai\Tools;
 use App\Models\Expense;
 use App\Models\Family;
 use App\Models\User;
+use App\Support\CurrencyFormatter;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
@@ -20,7 +21,7 @@ class RecordExpense implements Tool
      */
     public function description(): string
     {
-        return 'Records a new expense for the family. Requires amount (whole number in Naira), description, and date. Always call without confirmed=true first to preview the action.';
+        return 'Records a new expense for the family. Requires amount (whole number), description, and date. Always call without confirmed=true first to preview the action.';
     }
 
     /**
@@ -38,7 +39,7 @@ class RecordExpense implements Tool
         $confirmed = ($request['confirmed'] ?? false) === true;
 
         if (! $amount || $amount < 1) {
-            return json_encode(['error' => 'Amount is required and must be at least ₦1.'], JSON_THROW_ON_ERROR);
+            return json_encode(['error' => 'Amount is required and must be at least 1.'], JSON_THROW_ON_ERROR);
         }
 
         if (! $description) {
@@ -47,7 +48,7 @@ class RecordExpense implements Tool
 
         $family = $this->user->family;
         $currency = $family instanceof Family ? $family->currency : '₦';
-        $formattedAmount = $currency.number_format($amount, 2);
+        $formattedAmount = CurrencyFormatter::format($amount, $currency);
 
         if (! $confirmed) {
             return json_encode([

--- a/app/Ai/Tools/RecordFundAdjustment.php
+++ b/app/Ai/Tools/RecordFundAdjustment.php
@@ -7,6 +7,7 @@ namespace App\Ai\Tools;
 use App\Models\Family;
 use App\Models\FundAdjustment;
 use App\Models\User;
+use App\Support\CurrencyFormatter;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
@@ -20,7 +21,7 @@ class RecordFundAdjustment implements Tool
      */
     public function description(): string
     {
-        return 'Records a fund adjustment for the family (e.g., interest earned, donations received, corrections). Requires amount (whole number in Naira), description, and date. Always call without confirmed=true first to preview.';
+        return 'Records a fund adjustment for the family (e.g., interest earned, donations received, corrections). Requires amount (whole number), description, and date. Always call without confirmed=true first to preview.';
     }
 
     /**
@@ -38,7 +39,7 @@ class RecordFundAdjustment implements Tool
         $confirmed = ($request['confirmed'] ?? false) === true;
 
         if (! $amount || $amount < 1) {
-            return json_encode(['error' => 'Amount is required and must be at least ₦1.'], JSON_THROW_ON_ERROR);
+            return json_encode(['error' => 'Amount is required and must be at least 1.'], JSON_THROW_ON_ERROR);
         }
 
         if (! $description) {
@@ -47,7 +48,7 @@ class RecordFundAdjustment implements Tool
 
         $family = $this->user->family;
         $currency = $family instanceof Family ? $family->currency : '₦';
-        $formattedAmount = $currency.number_format($amount, 2);
+        $formattedAmount = CurrencyFormatter::format($amount, $currency);
 
         if (! $confirmed) {
             return json_encode([

--- a/app/Ai/Tools/RecordPayment.php
+++ b/app/Ai/Tools/RecordPayment.php
@@ -8,6 +8,7 @@ use App\Models\Family;
 use App\Models\Payment;
 use App\Models\User;
 use App\Services\PaymentAllocationService;
+use App\Support\CurrencyFormatter;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
@@ -21,7 +22,7 @@ class RecordPayment implements Tool
      */
     public function description(): string
     {
-        return 'Records a payment for a family member. Accepts the member name (or part of it), amount in Naira, payment date, optional notes, and optional target year/month. The payment is automatically allocated to the oldest unpaid contribution first. Always call without confirmed=true first to preview.';
+        return 'Records a payment for a family member. Accepts the member name (or part of it), amount, payment date, optional notes, and optional target year/month. The payment is automatically allocated to the oldest unpaid contribution first. Always call without confirmed=true first to preview.';
     }
 
     /**
@@ -46,15 +47,16 @@ class RecordPayment implements Tool
         }
 
         if (! $amount || $amount < 1) {
-            return json_encode(['error' => 'Amount is required and must be at least ₦1.'], JSON_THROW_ON_ERROR);
+            return json_encode(['error' => 'Amount is required and must be at least 1.'], JSON_THROW_ON_ERROR);
         }
 
         // Find member by name within the family
         $members = User::query()
             ->where('family_id', $this->user->family_id)
             ->active()
+            ->with('familyCategory:id,name,monthly_amount')
             ->where('name', 'like', "%{$memberName}%")
-            ->get(['id', 'name', 'category']);
+            ->get(['id', 'name', 'category', 'family_category_id']);
 
         if ($members->isEmpty()) {
             return json_encode(['error' => "No active family member found matching \"{$memberName}\"."], JSON_THROW_ON_ERROR);
@@ -71,7 +73,7 @@ class RecordPayment implements Tool
 
         $member = $members->first();
 
-        if (! $member->category) {
+        if ($member->getMonthlyAmount() === null) {
             return json_encode(['error' => "{$member->name} does not have a contribution category assigned. Please assign one first."], JSON_THROW_ON_ERROR);
         }
 
@@ -87,7 +89,7 @@ class RecordPayment implements Tool
 
         $family = $this->user->family;
         $currency = $family instanceof Family ? $family->currency : '₦';
-        $formattedAmount = $currency.number_format($amount, 2);
+        $formattedAmount = CurrencyFormatter::format($amount, $currency);
         $targetInfo = ($targetYear !== null && $targetMonth !== null)
             ? ' for '.now()->setYear($targetYear)->setMonth($targetMonth)->format('F Y')
             : '';

--- a/app/Http/Controllers/ContributionController.php
+++ b/app/Http/Controllers/ContributionController.php
@@ -104,7 +104,7 @@ class ContributionController extends Controller
     {
         $this->authorize('view', $contribution);
 
-        $contribution->load(['user', 'payments.recorder']);
+        $contribution->load(['user.familyCategory:id,name,monthly_amount', 'payments.recorder']);
         $contributionUser = $contribution->user;
 
         return Inertia::render('Contributions/Show', [
@@ -123,7 +123,7 @@ class ContributionController extends Controller
                     'id' => $contributionUser?->id,
                     'name' => $contributionUser?->name,
                     'email' => $contributionUser?->email,
-                    'category' => $contributionUser?->category?->label(),
+                    'category' => $contributionUser?->familyCategory->name ?? $contributionUser?->category?->label(),
                 ],
             ],
             'can_record_payment' => $this->user($request)->canRecordPayments(),

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -35,7 +35,7 @@ class DashboardController extends Controller
         // Eager-load payments (used for sum calculations) and user (for member filtering)
         $allContributions = Contribution::query()
             ->where('family_id', $user->family_id)
-            ->with(['user', 'payments.recorder'])
+            ->with(['user.familyCategory:id,name,monthly_amount', 'payments.recorder'])
             ->whereHas('user', fn ($q) => $q->whereNull('archived_at'))
             ->get();
 
@@ -47,7 +47,7 @@ class DashboardController extends Controller
         $membersNeedingContributions = User::query()
             ->where('family_id', $user->family_id)
             ->active()
-            ->whereNotNull('category')
+            ->payingMembers()
             ->whereNotIn('id', $membersWithContributions)
             ->exists();
 
@@ -141,6 +141,7 @@ class DashboardController extends Controller
                 'id' => $member?->id,
                 'name' => $member?->name,
                 'category' => $member?->category?->value,
+                'category_label' => $member?->familyCategory->name ?? $member?->category?->label(),
                 'expected_amount' => $contribution->expected_amount,
                 'total_paid' => $totalPaid,
                 'current_month_status' => $contribution->status->value,
@@ -171,7 +172,7 @@ class DashboardController extends Controller
                     'amount' => $payment->amount,
                     'paid_at' => $payment->paid_at->toDateString(),
                     'member_name' => $contribution->user instanceof User ? $contribution->user->name : 'Unknown',
-                    'category' => $contribution->user?->category,
+                    'category' => $contribution->user?->familyCategory->name ?? $contribution->user?->category?->label(),
                     'recorded_by' => $payment->recorder?->name,
                     'month' => $contribution->month,
                     'year' => $contribution->year,
@@ -261,6 +262,7 @@ class DashboardController extends Controller
                 'id' => $contribution->user?->id,
                 'name' => $contribution->user instanceof User ? $contribution->user->name : 'Unknown',
                 'category' => $contribution->user?->category?->value,
+                'category_label' => $contribution->user?->familyCategory->name ?? $contribution->user?->category?->label(),
                 'month' => $contribution->month,
                 'year' => $contribution->year,
                 'expected_amount' => $contribution->expected_amount,

--- a/app/Http/Controllers/FundAdjustmentController.php
+++ b/app/Http/Controllers/FundAdjustmentController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreFundAdjustmentRequest;
 use App\Models\FundAdjustment;
+use App\Support\CurrencyFormatter;
 use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -58,7 +59,7 @@ class FundAdjustmentController extends Controller
             'recorded_by' => $user->id,
         ]);
 
-        $formattedAmount = '₦'.number_format($amount, 2);
+        $formattedAmount = CurrencyFormatter::format($amount, $user->family?->currency);
 
         return redirect()->route('fund-adjustments.index')
             ->with('success', "Fund adjustment of {$formattedAmount} recorded successfully.");

--- a/app/Http/Controllers/MemberController.php
+++ b/app/Http/Controllers/MemberController.php
@@ -29,6 +29,7 @@ class MemberController extends Controller
         $members = User::query()
             ->where('family_id', $currentUser->family_id)
             ->active()
+            ->with('familyCategory:id,name,monthly_amount')
             ->orderBy('name')
             ->get()
             ->map(fn (User $user) => [
@@ -38,7 +39,7 @@ class MemberController extends Controller
                 'role' => $user->role->value,
                 'role_label' => $user->role->label(),
                 'category' => $user->category?->value,
-                'category_label' => $user->category?->label(),
+                'category_label' => $user->familyCategory->name ?? $user->category?->label(),
                 'monthly_amount' => $user->getMonthlyAmount(),
                 'is_archived' => $user->isArchived(),
             ]);
@@ -46,6 +47,7 @@ class MemberController extends Controller
         $archivedMembers = User::query()
             ->where('family_id', $currentUser->family_id)
             ->archived()
+            ->with('familyCategory:id,name,monthly_amount')
             ->orderBy('name')
             ->get()
             ->map(fn (User $user) => [
@@ -55,7 +57,7 @@ class MemberController extends Controller
                 'role' => $user->role->value,
                 'role_label' => $user->role->label(),
                 'category' => $user->category?->value,
-                'category_label' => $user->category?->label(),
+                'category_label' => $user->familyCategory->name ?? $user->category?->label(),
                 'monthly_amount' => $user->getMonthlyAmount(),
                 'archived_at' => $user->archived_at?->toDateString(),
                 'is_archived' => true,
@@ -119,6 +121,7 @@ class MemberController extends Controller
     public function show(User $member): Response
     {
         $currentUser = $this->authUser();
+        $member->loadMissing('familyCategory:id,name,monthly_amount');
 
         // Determine if user can view contribution history
         // (own profile OR has elevated permissions)
@@ -173,7 +176,7 @@ class MemberController extends Controller
                 'role' => $member->role->value,
                 'role_label' => $member->role->label(),
                 'category' => $member->category?->value,
-                'category_label' => $member->category?->label(),
+                'category_label' => $member->familyCategory->name ?? $member->category?->label(),
                 'monthly_amount' => $member->getMonthlyAmount(),
                 'is_archived' => $member->isArchived(),
                 'archived_at' => $member->archived_at?->toDateString(),

--- a/app/Http/Controllers/MemberPaymentController.php
+++ b/app/Http/Controllers/MemberPaymentController.php
@@ -13,6 +13,7 @@ use App\Models\PaystackTransaction;
 use App\Models\User;
 use App\Services\PaymentAllocationService;
 use App\Services\PaystackService;
+use App\Support\CurrencyFormatter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -56,7 +57,7 @@ class MemberPaymentController extends Controller
         return Inertia::render('Pay/Index', [
             'pending_contributions' => $pendingContributions,
             'category_amount' => $user->getMonthlyAmount() ?? 0,
-            'formatted_amount' => $user->category?->formattedAmount() ?? '₦0',
+            'formatted_amount' => CurrencyFormatter::format($user->getMonthlyAmount() ?? 0, $family instanceof Family ? $family->currency : null),
             'has_paystack' => $family instanceof Family && $family->hasBankDetails() && $paystackPublicKey !== '',
             'paystack_public_key' => $paystackPublicKey,
         ]);

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\StorePaymentRequest;
 use App\Models\Payment;
 use App\Models\User;
 use App\Services\PaymentAllocationService;
+use App\Support\CurrencyFormatter;
 use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -31,7 +32,8 @@ class PaymentController extends Controller
         $members = User::query()
             ->where('family_id', $currentUser->family_id)
             ->whereNull('archived_at')
-            ->whereNotNull('category')
+            ->payingMembers()
+            ->with('familyCategory:id,name,monthly_amount')
             ->orderBy('name')
             ->get()
             ->map(fn (User $member): array => [
@@ -39,7 +41,7 @@ class PaymentController extends Controller
                 'name' => $member->name,
                 'email' => $member->email,
                 'category' => $member->category?->value,
-                'category_label' => $member->category?->label(),
+                'category_label' => $member->familyCategory->name ?? $member->category?->label(),
                 'monthly_amount' => $member->getMonthlyAmount() ?? 0,
             ]);
 
@@ -54,6 +56,7 @@ class PaymentController extends Controller
     public function create(User $member): Response
     {
         $this->authorize('create', Payment::class);
+        $currency = $member->family->currency ?? $this->authUser()->family->currency ?? '₦';
 
         // Get member's pending (incomplete) contributions
         $pendingContributions = $member->contributions()
@@ -72,13 +75,19 @@ class PaymentController extends Controller
             ]);
 
         return Inertia::render('Payments/Create', [
-            'member' => $member->only(['id', 'name', 'email', 'category']),
+            'member' => [
+                'id' => $member->id,
+                'name' => $member->name,
+                'email' => $member->email,
+                'category' => $member->category?->value,
+                'category_label' => $member->familyCategory->name ?? $member->category?->label(),
+            ],
             'pending_contributions' => $pendingContributions,
-            'category_amount' => $member->category?->monthlyAmount(),
-            'formatted_amount' => $member->category?->formattedAmount(),
+            'category_amount' => $member->getMonthlyAmount() ?? 0,
+            'formatted_amount' => CurrencyFormatter::format($member->getMonthlyAmount() ?? 0, $currency),
             'categories' => collect(MemberCategory::cases())->map(fn ($cat) => [
                 'value' => $cat->value,
-                'label' => $cat->labelWithAmount(),
+                'label' => "{$cat->label()} (".CurrencyFormatter::format($cat->monthlyAmount(), $currency, 0).'/month)',
             ]),
         ]);
     }
@@ -104,7 +113,8 @@ class PaymentController extends Controller
         );
 
         $totalAllocated = (int) $payments->sum(fn (Payment $payment): int => $payment->amount);
-        $formattedAmount = '₦'.number_format($totalAllocated, 2);
+        $currency = $recordedBy->family->currency ?? $member->family->currency ?? '₦';
+        $formattedAmount = CurrencyFormatter::format($totalAllocated, $currency);
 
         return redirect()->route('dashboard')
             ->with('success', "Payment of {$formattedAmount} recorded for {$member->name}.");

--- a/app/Http/Controllers/PlatformAdminController.php
+++ b/app/Http/Controllers/PlatformAdminController.php
@@ -101,7 +101,7 @@ class PlatformAdminController extends Controller
     public function users(): Response
     {
         $users = User::query()
-            ->with('family')
+            ->with(['family', 'familyCategory:id,name,monthly_amount'])
             ->latest()
             ->paginate(20)
             ->through(fn (User $user) => [
@@ -109,7 +109,7 @@ class PlatformAdminController extends Controller
                 'name' => $user->name,
                 'email' => $user->email,
                 'role' => $user->role->label(),
-                'category' => $user->category?->label(),
+                'category' => $user->familyCategory->name ?? $user->category?->label(),
                 'family_name' => $user->family?->name,
                 'family_id' => $user->family_id,
                 'is_active' => $user->archived_at === null,
@@ -229,7 +229,7 @@ class PlatformAdminController extends Controller
     public function exportUsers(): StreamedResponse
     {
         $users = User::query()
-            ->with('family')
+            ->with(['family', 'familyCategory:id,name,monthly_amount'])
             ->latest()
             ->get();
 
@@ -250,7 +250,7 @@ class PlatformAdminController extends Controller
                     $user->email,
                     $user->family instanceof Family ? $user->family->name : '',
                     $user->role->label(),
-                    $user->category?->label() ?? '',
+                    $user->familyCategory->name ?? $user->category?->label() ?? '',
                     $user->archived_at === null ? 'Active' : 'Archived',
                     $user->created_at?->toDateString(),
                 ]);

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -52,8 +52,8 @@ class ReportController extends Controller
         $members = User::query()
             ->where('family_id', $familyId)
             ->whereNull('archived_at')
-            ->whereNotNull('category')
-            ->with('contributions.payments')
+            ->payingMembers()
+            ->with(['contributions.payments', 'familyCategory:id,name,monthly_amount'])
             ->paginate(15)
             ->through(function (User $member) use ($year, $month): array {
                 $contribution = $member->contributions->first(

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -39,6 +39,10 @@ class HandleInertiaRequests extends Middleware
 
         $user = $request->user();
 
+        if ($user instanceof User) {
+            $user->loadMissing('familyCategory:id,name,monthly_amount');
+        }
+
         return [
             ...parent::share($request),
             'name' => config('app.name'),
@@ -52,7 +56,7 @@ class HandleInertiaRequests extends Middleware
                     'role' => $user->role->value,
                     'role_label' => $user->role->label(),
                     'category' => $user->category?->value,
-                    'category_label' => $user->category?->label(),
+                    'category_label' => $user->familyCategory->name ?? $user->category?->label(),
                     'family_id' => $user->family_id,
                     'is_super_admin' => $user->is_super_admin,
                     'whatsapp_phone' => $user->whatsapp_phone,

--- a/app/Http/Requests/StoreExpenseRequest.php
+++ b/app/Http/Requests/StoreExpenseRequest.php
@@ -43,8 +43,8 @@ class StoreExpenseRequest extends FormRequest
     {
         return [
             'amount.required' => 'Please enter the expense amount.',
-            'amount.integer' => 'The amount must be a whole number in Naira.',
-            'amount.min' => 'The amount must be at least ₦1.',
+            'amount.integer' => 'The amount must be a whole number.',
+            'amount.min' => 'The amount must be at least 1.',
             'description.required' => 'Please enter a description for the expense.',
             'description.max' => 'The description must not exceed 1000 characters.',
             'spent_at.required' => 'Please enter the date the expense was incurred.',

--- a/app/Http/Requests/StoreFundAdjustmentRequest.php
+++ b/app/Http/Requests/StoreFundAdjustmentRequest.php
@@ -43,8 +43,8 @@ class StoreFundAdjustmentRequest extends FormRequest
     {
         return [
             'amount.required' => 'Please enter the adjustment amount.',
-            'amount.integer' => 'The amount must be a whole number in Naira.',
-            'amount.min' => 'The amount must be at least ₦1.',
+            'amount.integer' => 'The amount must be a whole number.',
+            'amount.min' => 'The amount must be at least 1.',
             'description.required' => 'Please enter a description for the adjustment.',
             'description.max' => 'The description must not exceed 1000 characters.',
             'recorded_at.required' => 'Please enter the date.',

--- a/app/Http/Requests/StorePaymentRequest.php
+++ b/app/Http/Requests/StorePaymentRequest.php
@@ -48,7 +48,7 @@ class StorePaymentRequest extends FormRequest
 
             if ($memberId !== null) {
                 $member = User::query()->find($memberId);
-                if ($member && ! $member->category) {
+                if ($member && $member->getMonthlyAmount() === null) {
                     $validator->errors()->add('member_id', 'This member does not have a contribution category assigned.');
                 }
             }
@@ -85,8 +85,8 @@ class StorePaymentRequest extends FormRequest
             'member_id.required' => 'Please select a family member.',
             'member_id.exists' => 'The selected member does not exist.',
             'amount.required' => 'Please enter the payment amount.',
-            'amount.integer' => 'The amount must be a whole number in Naira.',
-            'amount.min' => 'The amount must be at least ₦5.',
+            'amount.integer' => 'The amount must be a whole number.',
+            'amount.min' => 'The amount must be at least 1.',
             'paid_at.required' => 'Please enter the payment date.',
             'paid_at.date' => 'Please enter a valid date.',
         ];

--- a/app/Models/Contribution.php
+++ b/app/Models/Contribution.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\PaymentStatus;
+use App\Support\CurrencyFormatter;
 use Carbon\Carbon;
 use Database\Factories\ContributionFactory;
 use DateTimeInterface;
@@ -305,7 +306,7 @@ class Contribution extends Model
      */
     public function formattedExpectedAmount(): string
     {
-        return '₦'.number_format($this->expected_amount, 2);
+        return CurrencyFormatter::format($this->expected_amount, $this->family?->currency);
     }
 
     /**
@@ -313,7 +314,7 @@ class Contribution extends Model
      */
     public function formattedTotalPaid(): string
     {
-        return '₦'.number_format($this->total_paid, 2);
+        return CurrencyFormatter::format($this->total_paid, $this->family?->currency);
     }
 
     /**
@@ -321,6 +322,6 @@ class Contribution extends Model
      */
     public function formattedBalance(): string
     {
-        return '₦'.number_format($this->balance, 2);
+        return CurrencyFormatter::format($this->balance, $this->family?->currency);
     }
 }

--- a/app/Models/Expense.php
+++ b/app/Models/Expense.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Support\CurrencyFormatter;
 use Database\Factories\ExpenseFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -111,6 +112,6 @@ class Expense extends Model
      */
     public function getFormattedAmountAttribute(): string
     {
-        return '₦'.number_format($this->amount, 2);
+        return CurrencyFormatter::format($this->amount, $this->family?->currency);
     }
 }

--- a/app/Models/FamilyCategory.php
+++ b/app/Models/FamilyCategory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Support\CurrencyFormatter;
 use Database\Factories\FamilyCategoryFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -84,7 +85,7 @@ class FamilyCategory extends Model
      */
     public function getFormattedAmountAttribute(): string
     {
-        return '₦'.number_format($this->monthly_amount, 0);
+        return CurrencyFormatter::format($this->monthly_amount, $this->family?->currency, 0);
     }
 
     /**

--- a/app/Models/FundAdjustment.php
+++ b/app/Models/FundAdjustment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Support\CurrencyFormatter;
 use Database\Factories\FundAdjustmentFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -100,6 +101,6 @@ class FundAdjustment extends Model
      */
     public function getFormattedAmountAttribute(): string
     {
-        return '₦'.number_format($this->amount, 2);
+        return CurrencyFormatter::format($this->amount, $this->family?->currency);
     }
 }

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Support\CurrencyFormatter;
 use Database\Factories\PaymentFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -152,7 +153,7 @@ class Payment extends Model
      */
     public function getFormattedAmountAttribute(): string
     {
-        return '₦'.number_format($this->amount, 2);
+        return CurrencyFormatter::format($this->amount, $this->contribution?->family?->currency);
     }
 
     // =========================================================================

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -214,14 +214,17 @@ class User extends Authenticatable implements MustVerifyEmail, OAuthenticatable,
     }
 
     /**
-     * Scope to users who can pay (have a category).
+     * Scope to users who can pay (have a contribution category).
      *
      * @param  Builder<User>  $query
      * @return Builder<User>
      */
     public function scopePayingMembers(Builder $query): Builder
     {
-        return $query->whereNotNull('category');
+        return $query->where(function (Builder $query): void {
+            $query->whereNotNull('category')
+                ->orWhereNotNull('family_category_id');
+        });
     }
 
     /**
@@ -323,7 +326,7 @@ class User extends Authenticatable implements MustVerifyEmail, OAuthenticatable,
     }
 
     /**
-     * Get the monthly contribution amount in Naira for this user.
+     * Get the monthly contribution amount for this user.
      */
     public function getMonthlyAmount(): ?int
     {

--- a/app/Support/CurrencyFormatter.php
+++ b/app/Support/CurrencyFormatter.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class CurrencyFormatter
+{
+    public static function format(int|float $amount, ?string $currency, int $fractionDigits = 2): string
+    {
+        $normalizedCurrency = trim((string) $currency);
+        $normalizedCurrency = $normalizedCurrency !== '' ? $normalizedCurrency : '₦';
+        $formattedAmount = number_format((float) $amount, $fractionDigits);
+
+        if (preg_match('/^[A-Z]{3}$/', $normalizedCurrency) === 1) {
+            return "{$normalizedCurrency} {$formattedAmount}";
+        }
+
+        return "{$normalizedCurrency}{$formattedAmount}";
+    }
+}

--- a/resources/js/components/NotificationBell.vue
+++ b/resources/js/components/NotificationBell.vue
@@ -13,12 +13,17 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { useCurrencyFormatter } from '@/lib/currency';
 import type { AppNotification } from '@/types';
 import { Link, router, usePage } from '@inertiajs/vue3';
 import { Bell } from 'lucide-vue-next';
 import { computed } from 'vue';
 
 const page = usePage();
+const { formatCurrency } = useCurrencyFormatter({
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+});
 
 const notifications = computed(() => page.props.notifications);
 const unreadCount = computed(() => notifications.value?.unread_count ?? 0);
@@ -36,10 +41,13 @@ function handleMarkAllAsRead(): void {
 
 function formatNotificationMessage(notification: AppNotification): string {
     const { data } = notification;
+    const amountOwed = formatCurrency(Number(data.amount_owed ?? 0));
+
     if (data.type === 'follow_up') {
-        return `Follow-up: Your ${data.period_label} contribution of ₦${Number(data.amount_owed).toLocaleString()} is due today`;
+        return `Follow-up: Your ${data.period_label} contribution of ${amountOwed} is due today`;
     }
-    return `Reminder: Your ${data.period_label} contribution of ₦${Number(data.amount_owed).toLocaleString()} is due soon`;
+
+    return `Reminder: Your ${data.period_label} contribution of ${amountOwed} is due soon`;
 }
 </script>
 

--- a/resources/js/components/contributions/AggregateStats.vue
+++ b/resources/js/components/contributions/AggregateStats.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useCurrencyFormatter } from '@/lib/currency';
 defineProps<{
     totalExpected: number;
     totalCollected: number;
@@ -7,13 +8,7 @@ defineProps<{
     periodLabel?: string;
 }>();
 
-// Format currency in Naira
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 </script>
 
 <template>

--- a/resources/js/components/contributions/ContributionCard.vue
+++ b/resources/js/components/contributions/ContributionCard.vue
@@ -2,6 +2,7 @@
 import { show as showContribution } from '@/actions/App/Http/Controllers/ContributionController';
 import PaymentHistory from '@/components/contributions/PaymentHistory.vue';
 import StatusBadge from '@/components/contributions/StatusBadge.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { Link } from '@inertiajs/vue3';
 import { ChevronDown, ChevronUp } from 'lucide-vue-next';
 import { ref } from 'vue';
@@ -39,12 +40,7 @@ defineProps<Props>();
 
 const showPayments = ref(false);
 
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 
 function togglePayments() {
     showPayments.value = !showPayments.value;

--- a/resources/js/components/contributions/MemberListItem.vue
+++ b/resources/js/components/contributions/MemberListItem.vue
@@ -6,6 +6,7 @@ import {
 } from '@/actions/App/Http/Controllers/MemberController';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { Link, router } from '@inertiajs/vue3';
 import { Archive, Eye, Pencil, RotateCcw } from 'lucide-vue-next';
 
@@ -34,12 +35,7 @@ const emit = defineEmits<{
     restored: [member: Member];
 }>();
 
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 
 function getRoleBadgeVariant(role: string) {
     switch (role) {

--- a/resources/js/components/contributions/PaymentHistory.vue
+++ b/resources/js/components/contributions/PaymentHistory.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useCurrencyFormatter } from '@/lib/currency';
 interface Payment {
     id: number;
     amount: number;
@@ -17,12 +18,7 @@ interface Props {
 
 defineProps<Props>();
 
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 
 function formatDate(date: string): string {
     return new Date(date).toLocaleDateString('en-NG', {

--- a/resources/js/components/dashboard/MemberContributionStatus.vue
+++ b/resources/js/components/dashboard/MemberContributionStatus.vue
@@ -2,12 +2,14 @@
 import { show as showContribution } from '@/actions/App/Http/Controllers/ContributionController';
 import { create as createPayment } from '@/actions/App/Http/Controllers/PaymentController';
 import StatusBadge from '@/components/contributions/StatusBadge.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { Link } from '@inertiajs/vue3';
 
 interface Member {
     id: number;
     name: string;
-    category: string;
+    category: string | null;
+    category_label: string | null;
     expected_amount: number;
     total_paid: number;
     current_month_status: string;
@@ -21,16 +23,14 @@ defineProps<{
     canRecordPayments: boolean;
 }>();
 
-// Format currency in Naira
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 
 // Format category label
-function formatCategory(category: string): string {
+function formatCategory(category: string | null): string {
+    if (!category) {
+        return 'Contribution';
+    }
+
     return category.charAt(0).toUpperCase() + category.slice(1);
 }
 </script>
@@ -59,7 +59,7 @@ function formatCategory(category: string): string {
                         member.category === 'student',
                 }"
             >
-                {{ formatCategory(member.category) }}
+                {{ member.category_label ?? formatCategory(member.category) }}
             </span>
         </td>
         <td class="px-3 py-3 sm:px-4">

--- a/resources/js/components/dashboard/OverdueMembersModal.vue
+++ b/resources/js/components/dashboard/OverdueMembersModal.vue
@@ -8,12 +8,14 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { Link } from '@inertiajs/vue3';
 
 export interface OverdueMember {
     id: number;
     name: string;
-    category: string;
+    category: string | null;
+    category_label: string | null;
     month: number;
     year: number;
     expected_amount: number;
@@ -28,12 +30,7 @@ defineProps<{
 
 const isOpen = defineModel<boolean>('isOpen');
 
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 
 function formatMonth(month: number, year: number): string {
     return new Date(year, month - 1).toLocaleDateString('en-NG', {
@@ -42,7 +39,11 @@ function formatMonth(month: number, year: number): string {
     });
 }
 
-function formatCategory(category: string): string {
+function formatCategory(category: string | null): string {
+    if (!category) {
+        return 'Contribution';
+    }
+
     return category.charAt(0).toUpperCase() + category.slice(1);
 }
 
@@ -111,14 +112,21 @@ const categoryColors: Record<string, string> = {
                                     {{ member.name }}
                                 </span>
                                 <span
-                                    v-if="member.category"
+                                    v-if="
+                                        member.category_label || member.category
+                                    "
                                     class="rounded-full px-2 py-0.5 text-xs font-medium"
                                     :class="
-                                        categoryColors[member.category] ??
+                                        (member.category
+                                            ? categoryColors[member.category]
+                                            : null) ??
                                         'bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300'
                                     "
                                 >
-                                    {{ formatCategory(member.category) }}
+                                    {{
+                                        member.category_label ??
+                                        formatCategory(member.category)
+                                    }}
                                 </span>
                             </div>
                             <div

--- a/resources/js/components/dashboard/RecentPayments.vue
+++ b/resources/js/components/dashboard/RecentPayments.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useCurrencyFormatter } from '@/lib/currency';
 interface Payment {
     id: number;
     amount: number;
@@ -14,13 +15,7 @@ defineProps<{
     payments: Payment[];
 }>();
 
-// Format currency in Naira
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 
 // Format date
 function formatDate(dateString: string): string {

--- a/resources/js/components/dashboard/SummaryCards.vue
+++ b/resources/js/components/dashboard/SummaryCards.vue
@@ -7,6 +7,7 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/components/ui/dialog';
+import { useCurrencyFormatter } from '@/lib/currency';
 import type { MonthlyBreakdown } from '@/types/dashboard';
 import { Link } from '@inertiajs/vue3';
 import { ref } from 'vue';
@@ -29,13 +30,7 @@ const emit = defineEmits<{
 
 const showBreakdownModal = ref(false);
 
-// Format currency in Naira
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 
 function formatMonth(month: number, year: number): string {
     return new Date(year, month - 1).toLocaleDateString('en-NG', {

--- a/resources/js/lib/currency.ts
+++ b/resources/js/lib/currency.ts
@@ -1,0 +1,68 @@
+import type { AppPageProps } from '@/types';
+import { usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
+
+interface CurrencyFormatOptions {
+    minimumFractionDigits?: number;
+    maximumFractionDigits?: number;
+}
+
+const ISO_CURRENCY_PATTERN = /^[A-Z]{3}$/;
+
+export function normalizeCurrency(currency?: string | null): string {
+    const normalized = currency?.trim();
+
+    return normalized && normalized.length > 0 ? normalized : '₦';
+}
+
+export function formatCurrencyAmount(
+    amount: number | null | undefined,
+    currency?: string | null,
+    options: CurrencyFormatOptions = {},
+): string {
+    const normalizedCurrency = normalizeCurrency(currency);
+    const value = Number(amount ?? 0);
+    const minimumFractionDigits =
+        options.minimumFractionDigits ?? options.maximumFractionDigits ?? 2;
+    const maximumFractionDigits =
+        options.maximumFractionDigits ?? minimumFractionDigits;
+    const fractionOptions = {
+        minimumFractionDigits,
+        maximumFractionDigits,
+    };
+
+    if (ISO_CURRENCY_PATTERN.test(normalizedCurrency)) {
+        return new Intl.NumberFormat('en', {
+            style: 'currency',
+            currency: normalizedCurrency,
+            currencyDisplay: 'narrowSymbol',
+            ...fractionOptions,
+        }).format(value);
+    }
+
+    return `${normalizedCurrency}${value.toLocaleString('en', fractionOptions)}`;
+}
+
+export function useCurrencyFormatter(
+    defaultOptions: CurrencyFormatOptions = {},
+) {
+    const page = usePage<AppPageProps>();
+    const currency = computed(() =>
+        normalizeCurrency(page.props.family?.currency),
+    );
+
+    function formatCurrency(
+        amount: number | null | undefined,
+        options: CurrencyFormatOptions = {},
+    ): string {
+        return formatCurrencyAmount(amount, currency.value, {
+            ...defaultOptions,
+            ...options,
+        });
+    }
+
+    return {
+        currency,
+        formatCurrency,
+    };
+}

--- a/resources/js/pages/Contributions/My.vue
+++ b/resources/js/pages/Contributions/My.vue
@@ -3,6 +3,7 @@ import AccountDetails from '@/components/AccountDetails.vue';
 import AggregateStats from '@/components/contributions/AggregateStats.vue';
 import ContributionCard from '@/components/contributions/ContributionCard.vue';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { dashboard } from '@/routes';
 import { type BreadcrumbItem } from '@/types';
 import { Head } from '@inertiajs/vue3';
@@ -84,12 +85,7 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 </script>
 
 <template>

--- a/resources/js/pages/Contributions/Show.vue
+++ b/resources/js/pages/Contributions/Show.vue
@@ -19,6 +19,7 @@ import {
     TableRow,
 } from '@/components/ui/table';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { dashboard } from '@/routes';
 import type { BreadcrumbItem } from '@/types';
 import { Head, Link } from '@inertiajs/vue3';
@@ -76,10 +77,7 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-// Helper to format amount in Naira
-const formatAmount = (amount: number): string => {
-    return `₦${amount.toLocaleString('en-NG', { minimumFractionDigits: 2 })}`;
-};
+const { formatCurrency: formatAmount } = useCurrencyFormatter();
 
 // Helper to format date
 const formatDate = (dateStr: string): string => {

--- a/resources/js/pages/Dashboard/Index.vue
+++ b/resources/js/pages/Dashboard/Index.vue
@@ -13,6 +13,7 @@ import OverdueMembersModal from '@/components/dashboard/OverdueMembersModal.vue'
 import RecentPayments from '@/components/dashboard/RecentPayments.vue';
 import SummaryCards from '@/components/dashboard/SummaryCards.vue';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { dashboard } from '@/routes';
 import { type BreadcrumbItem } from '@/types';
 import type { MonthlyBreakdown } from '@/types/dashboard';
@@ -37,7 +38,8 @@ interface Summary {
 interface MemberStatus {
     id: number;
     name: string;
-    category: string;
+    category: string | null;
+    category_label: string | null;
     expected_amount: number;
     total_paid: number;
     current_month_status: string;
@@ -123,15 +125,13 @@ function generateContributions() {
     );
 }
 
-// Format currency in Naira
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 
-function formatCategory(category: string): string {
+function formatCategory(category: string | null): string {
+    if (!category) {
+        return 'Contribution';
+    }
+
     return category.charAt(0).toUpperCase() + category.slice(1);
 }
 </script>
@@ -246,6 +246,7 @@ function formatCategory(category: string): string {
                                             class="mt-1 text-xs text-muted-foreground"
                                         >
                                             {{
+                                                member.category_label ??
                                                 formatCategory(member.category)
                                             }}
                                         </p>

--- a/resources/js/pages/Expenses/Create.vue
+++ b/resources/js/pages/Expenses/Create.vue
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import type { BreadcrumbItem } from '@/types';
 import { Form, Head } from '@inertiajs/vue3';
 import { ref } from 'vue';
@@ -24,6 +25,7 @@ const breadcrumbs: BreadcrumbItem[] = [
 const amount = ref<string>('');
 const description = ref<string>('');
 const spentAt = ref<string>(new Date().toISOString().split('T')[0]);
+const { currency } = useCurrencyFormatter();
 </script>
 
 <template>
@@ -43,13 +45,13 @@ const spentAt = ref<string>(new Date().toISOString().split('T')[0]);
             >
                 <!-- Amount Field -->
                 <div class="grid gap-2">
-                    <Label for="amount">Amount (₦)</Label>
+                    <Label for="amount">Amount ({{ currency }})</Label>
                     <Input
                         id="amount"
                         type="number"
                         name="amount"
                         v-model="amount"
-                        placeholder="Enter amount in Naira"
+                        :placeholder="`Enter amount in ${currency}`"
                         required
                         min="1"
                         step="1"

--- a/resources/js/pages/Expenses/Index.vue
+++ b/resources/js/pages/Expenses/Index.vue
@@ -5,6 +5,7 @@ import {
 } from '@/actions/App/Http/Controllers/ExpenseController';
 import { Button } from '@/components/ui/button';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, router } from '@inertiajs/vue3';
 import { Plus, Receipt, Trash2 } from 'lucide-vue-next';
@@ -39,12 +40,7 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 
 function formatDate(date: string): string {
     return new Date(date).toLocaleDateString('en-NG', {

--- a/resources/js/pages/Family/Settings.vue
+++ b/resources/js/pages/Family/Settings.vue
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { formatCurrencyAmount } from '@/lib/currency';
 import { type BreadcrumbItem } from '@/types';
 import { Form, Head, router } from '@inertiajs/vue3';
 import { Check, ChevronsUpDown, Pencil, Plus, Trash2 } from 'lucide-vue-next';
@@ -112,7 +113,10 @@ const editingCategory = ref<Category | null>(null);
 const showNewCategoryForm = ref(false);
 
 function formatCurrency(amount: number): string {
-    return `${props.family.currency}${amount.toLocaleString()}`;
+    return formatCurrencyAmount(amount, props.family.currency, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+    });
 }
 
 function deleteCategory(id: number): void {

--- a/resources/js/pages/FundAdjustments/Index.vue
+++ b/resources/js/pages/FundAdjustments/Index.vue
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { type BreadcrumbItem } from '@/types';
 import { Form, Head, Link, router } from '@inertiajs/vue3';
 import { Landmark, Plus, Trash2 } from 'lucide-vue-next';
@@ -48,13 +49,7 @@ const showForm = ref(false);
 const amount = ref<string>('');
 const description = ref<string>('');
 const recordedAt = ref<string>(new Date().toISOString().split('T')[0]);
-
-function formatCurrency(value: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(value);
-}
+const { currency, formatCurrency } = useCurrencyFormatter();
 
 function formatDate(date: string): string {
     return new Date(date).toLocaleDateString('en-NG', {
@@ -133,13 +128,13 @@ function resetForm(): void {
                 >
                     <div class="grid gap-4 sm:grid-cols-2">
                         <div class="grid gap-2">
-                            <Label for="amount">Amount (₦)</Label>
+                            <Label for="amount">Amount ({{ currency }})</Label>
                             <Input
                                 id="amount"
                                 type="number"
                                 name="amount"
                                 v-model="amount"
-                                placeholder="Enter amount in Naira"
+                                :placeholder="`Enter amount in ${currency}`"
                                 required
                                 min="1"
                                 step="1"

--- a/resources/js/pages/Members/Create.vue
+++ b/resources/js/pages/Members/Create.vue
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { type BreadcrumbItem } from '@/types';
 import { Form, Head, Link, usePage } from '@inertiajs/vue3';
 import { ArrowUpCircle } from 'lucide-vue-next';
@@ -56,12 +57,7 @@ const canAddMore = computed(
 );
 const subscription = computed(() => page.props.subscription);
 
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 </script>
 
 <template>

--- a/resources/js/pages/Members/Edit.vue
+++ b/resources/js/pages/Members/Edit.vue
@@ -18,6 +18,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, router } from '@inertiajs/vue3';
 import { computed, reactive, ref } from 'vue';
@@ -96,12 +97,7 @@ const newRoleLabel = computed(() => {
     return role ? role.label : selectedRole.value;
 });
 
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 
 function handleSubmit() {
     // If role changed, show confirmation dialog first

--- a/resources/js/pages/Members/Index.vue
+++ b/resources/js/pages/Members/Index.vue
@@ -7,6 +7,7 @@ import {
 import MemberListItem from '@/components/contributions/MemberListItem.vue';
 import { Button } from '@/components/ui/button';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, usePage } from '@inertiajs/vue3';
 import {
@@ -60,12 +61,7 @@ const page = usePage();
 const subscription = computed(() => page.props.subscription);
 const canAddMore = computed(() => subscription.value?.can_add_members ?? true);
 
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 </script>
 
 <template>

--- a/resources/js/pages/Members/Show.vue
+++ b/resources/js/pages/Members/Show.vue
@@ -18,6 +18,7 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, router } from '@inertiajs/vue3';
 import {
@@ -203,12 +204,7 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 
 function formatDate(dateStr: string): string {
     return new Date(dateStr).toLocaleDateString('en-NG', {

--- a/resources/js/pages/Notifications/Index.vue
+++ b/resources/js/pages/Notifications/Index.vue
@@ -7,9 +7,10 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { dashboard } from '@/routes';
 import type { BreadcrumbItem } from '@/types';
-import { Head, Link, router, usePage } from '@inertiajs/vue3';
+import { Head, Link, router } from '@inertiajs/vue3';
 import {
     AlertTriangle,
     Bell,
@@ -73,7 +74,10 @@ interface Props {
 }
 
 const props = defineProps<Props>();
-const page = usePage();
+const { formatCurrency } = useCurrencyFormatter({
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+});
 
 const emptyFeed: PaginatedNotifications = {
     data: [],
@@ -106,7 +110,6 @@ const summary = computed(() => props.notificationSummary ?? defaultSummary);
 const filters = computed(() => props.notificationFilters ?? defaultFilters);
 const hasNotifications = computed(() => feed.value.data.length > 0);
 const hasUnread = computed(() => summary.value.unread > 0);
-const currencySymbol = computed(() => page.props.family?.currency ?? '₦');
 
 const statusFilters = computed(() => [
     { label: 'All', value: 'all' as const, count: summary.value.total },
@@ -220,9 +223,7 @@ function notificationIconTone(notification: NotificationItem): string {
 }
 
 function formatMoney(amount?: number | string): string {
-    const value = Number(amount ?? 0);
-
-    return `${currencySymbol.value}${value.toLocaleString()}`;
+    return formatCurrency(Number(amount ?? 0));
 }
 
 function formatDate(dateString?: string | null): string {

--- a/resources/js/pages/Pay/Index.vue
+++ b/resources/js/pages/Pay/Index.vue
@@ -8,6 +8,7 @@ import HeadingSmall from '@/components/HeadingSmall.vue';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { dashboard } from '@/routes';
 import type { BreadcrumbItem } from '@/types';
 import { Head, router } from '@inertiajs/vue3';
@@ -36,7 +37,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
     pending_contributions: () => [],
     category_amount: 0,
-    formatted_amount: '₦0',
+    formatted_amount: '',
     has_paystack: false,
     paystack_public_key: '',
 });
@@ -48,10 +49,7 @@ const breadcrumbs: BreadcrumbItem[] = [
 
 const selectedIds = ref<number[]>([]);
 const processing = ref(false);
-
-const formatAmount = (amount: number): string => {
-    return `₦${amount.toLocaleString('en-NG', { minimumFractionDigits: 2 })}`;
-};
+const { formatCurrency: formatAmount } = useCurrencyFormatter();
 
 const totalSelected = computed(() => {
     return props.pending_contributions

--- a/resources/js/pages/Payments/Create.vue
+++ b/resources/js/pages/Payments/Create.vue
@@ -14,6 +14,7 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { dashboard } from '@/routes';
 import type { BreadcrumbItem } from '@/types';
 import { Form, Head } from '@inertiajs/vue3';
@@ -23,7 +24,8 @@ interface Member {
     id: number;
     name: string;
     email: string;
-    category: string;
+    category: string | null;
+    category_label: string | null;
 }
 
 interface PendingContribution {
@@ -68,13 +70,8 @@ const amount = ref<string>('');
 const selectedMonth = ref<string>('');
 const paidAt = ref<string>(new Date().toISOString().split('T')[0]);
 const notes = ref<string>('');
+const { currency, formatCurrency: formatAmount } = useCurrencyFormatter();
 
-// Helper to format amount in Naira
-const formatAmount = (amount: number): string => {
-    return `₦${amount.toLocaleString('en-NG', { minimumFractionDigits: 2 })}`;
-};
-
-// Quick amount buttons (values in Naira)
 const quickAmounts = computed(() => [
     { label: '1 Month', value: props.category_amount },
     { label: '2 Months', value: props.category_amount * 2 },
@@ -107,7 +104,7 @@ const targetMonth = computed(() => {
         <div class="mx-auto max-w-2xl space-y-6 p-4">
             <HeadingSmall
                 :title="`Record Payment for ${member.name}`"
-                :description="`${member.category} category - ${formatted_amount}/month`"
+                :description="`${member.category_label ?? member.category ?? 'Contribution'} - ${formatted_amount}/month`"
             />
 
             <!-- Pending Contributions Summary -->
@@ -174,13 +171,13 @@ const targetMonth = computed(() => {
 
                 <!-- Amount Field -->
                 <div class="grid gap-2">
-                    <Label for="amount">Amount (₦)</Label>
+                    <Label for="amount">Amount ({{ currency }})</Label>
                     <Input
                         id="amount"
                         type="number"
                         name="amount"
                         v-model="amount"
-                        placeholder="Enter amount in Naira"
+                        :placeholder="`Enter amount in ${currency}`"
                         required
                         min="1"
                         step="1"
@@ -206,11 +203,7 @@ const targetMonth = computed(() => {
                                 amount === quick.value.toString(),
                         }"
                     >
-                        {{ quick.label }} (₦{{
-                            quick.value.toLocaleString('en-NG', {
-                                minimumFractionDigits: 2,
-                            })
-                        }})
+                        {{ quick.label }} ({{ formatAmount(quick.value) }})
                     </Button>
                 </div>
 

--- a/resources/js/pages/Payments/Index.vue
+++ b/resources/js/pages/Payments/Index.vue
@@ -5,6 +5,7 @@ import {
     index,
 } from '@/actions/App/Http/Controllers/PaymentController';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link } from '@inertiajs/vue3';
 import { ChevronRight, CreditCard, Users } from 'lucide-vue-next';
@@ -46,12 +47,7 @@ const filteredMembers = computed(() => {
     );
 });
 
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 </script>
 
 <template>

--- a/resources/js/pages/Platform/FamilyDetail.vue
+++ b/resources/js/pages/Platform/FamilyDetail.vue
@@ -15,6 +15,7 @@ import {
     DialogTitle,
 } from '@/components/ui/dialog';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { formatCurrencyAmount } from '@/lib/currency';
 import { type BreadcrumbItem } from '@/types';
 import { Head, router } from '@inertiajs/vue3';
 import { Ban, CheckCircle } from 'lucide-vue-next';
@@ -82,7 +83,10 @@ const breadcrumbs = computed<BreadcrumbItem[]>(() => [
 ]);
 
 function formatCurrency(amount: number): string {
-    return `${props.family.currency}${amount.toLocaleString()}`;
+    return formatCurrencyAmount(amount, props.family.currency, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+    });
 }
 
 const showSuspendDialog = ref(false);

--- a/resources/js/pages/Reports/Annual.vue
+++ b/resources/js/pages/Reports/Annual.vue
@@ -6,6 +6,7 @@ import {
 } from '@/actions/App/Http/Controllers/ReportController';
 import { Button } from '@/components/ui/button';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, router } from '@inertiajs/vue3';
 import {
@@ -67,13 +68,7 @@ const breadcrumbs = computed<BreadcrumbItem[]>(() => [
     },
 ]);
 
-// Format currency in Naira
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 
 // Navigate to a different year
 function navigateToYear(year: number) {

--- a/resources/js/pages/Reports/Monthly.vue
+++ b/resources/js/pages/Reports/Monthly.vue
@@ -5,6 +5,7 @@ import {
 } from '@/actions/App/Http/Controllers/ReportController';
 import { Button } from '@/components/ui/button';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { useCurrencyFormatter } from '@/lib/currency';
 import { type BreadcrumbItem } from '@/types';
 import { Head, Link, router } from '@inertiajs/vue3';
 import {
@@ -107,13 +108,7 @@ const monthNames = [
     'December',
 ];
 
-// Format currency in Naira
-function formatCurrency(amount: number): string {
-    return new Intl.NumberFormat('en-NG', {
-        style: 'currency',
-        currency: 'NGN',
-    }).format(amount);
-}
+const { formatCurrency } = useCurrencyFormatter();
 
 // Navigate to a different month
 function navigateToMonth(year: number, month: number) {

--- a/tests/Feature/FundAdjustments/FundAdjustmentCrudTest.php
+++ b/tests/Feature/FundAdjustments/FundAdjustmentCrudTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\Family;
 use App\Models\FundAdjustment;
 use App\Models\User;
 use Inertia\Testing\AssertableInertia as Assert;
@@ -84,6 +85,22 @@ it('allows financial secretary to store a fund adjustment', function () {
 
     $adjustment = FundAdjustment::query()->firstOrFail();
     expect($adjustment->recorded_by)->toBe($this->financialSecretary->id);
+});
+
+it('uses the family currency in the fund adjustment recorded flash message', function () {
+    $family = Family::factory()->create(['currency' => 'QAR']);
+    $financialSecretary = User::factory()->financialSecretary()->create([
+        'family_id' => $family->id,
+    ]);
+
+    $this->actingAs($financialSecretary)
+        ->post(route('fund-adjustments.store'), [
+            'amount' => 450,
+            'description' => 'Opening balance',
+            'recorded_at' => '2026-06-08',
+        ])
+        ->assertRedirect(route('fund-adjustments.index'))
+        ->assertSessionHas('success', 'Fund adjustment of QAR 450.00 recorded successfully.');
 });
 
 it('denies regular member from storing a fund adjustment', function () {

--- a/tests/Feature/MemberPaymentTest.php
+++ b/tests/Feature/MemberPaymentTest.php
@@ -6,11 +6,13 @@ use App\Enums\TransactionStatus;
 use App\Enums\TransactionType;
 use App\Models\Contribution;
 use App\Models\Family;
+use App\Models\FamilyCategory;
 use App\Models\Payment;
 use App\Models\PaystackTransaction;
 use App\Models\PlatformPlan;
 use App\Models\User;
 use Illuminate\Support\Facades\Http;
+use Inertia\Testing\AssertableInertia as Assert;
 
 beforeEach(function () {
     config([
@@ -42,6 +44,29 @@ it('shows the pay page for authenticated member', function () {
     $this->actingAs($member)
         ->get(route('pay.index'))
         ->assertSuccessful();
+});
+
+it('shows the member monthly amount with the family currency', function () {
+    $family = Family::factory()->create(['currency' => 'QAR']);
+    $monthlyDues = FamilyCategory::factory()->create([
+        'family_id' => $family->id,
+        'name' => 'Monthly Dues',
+        'monthly_amount' => 100,
+    ]);
+    $member = User::factory()->member()->create([
+        'family_id' => $family->id,
+        'category' => null,
+        'family_category_id' => $monthlyDues->id,
+    ]);
+
+    $this->actingAs($member)
+        ->get(route('pay.index'))
+        ->assertSuccessful()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('Pay/Index')
+            ->where('category_amount', 100)
+            ->where('formatted_amount', 'QAR 100.00')
+        );
 });
 
 it('redirects guests from pay page', function () {

--- a/tests/Feature/Models/ContributionTest.php
+++ b/tests/Feature/Models/ContributionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Enums\PaymentStatus;
 use App\Models\Contribution;
+use App\Models\Family;
 use App\Models\Payment;
 use App\Models\User;
 use Carbon\Carbon;
@@ -57,4 +58,20 @@ it('uses eager loaded payments for total paid and explicit due dates when presen
         ->and($loaded->isPaid())->toBeTrue()
         ->and($loaded->canAcceptPayment())->toBeFalse()
         ->and($loaded->due_date->toDateString())->toBe('2026-05-20');
+});
+
+it('formats contribution amounts with the family currency', function () {
+    $family = Family::factory()->create(['currency' => 'QAR']);
+    $member = User::factory()->member()->employed()->create([
+        'family_id' => $family->id,
+    ]);
+    $contribution = Contribution::factory()->forUser($member)->create([
+        'family_id' => $family->id,
+        'expected_amount' => 4000,
+    ]);
+    Payment::factory()->forContribution($contribution)->create(['amount' => 1000]);
+
+    expect($contribution->formattedExpectedAmount())->toBe('QAR 4,000.00')
+        ->and($contribution->formattedTotalPaid())->toBe('QAR 1,000.00')
+        ->and($contribution->formattedBalance())->toBe('QAR 3,000.00');
 });

--- a/tests/Feature/Models/ExpenseTest.php
+++ b/tests/Feature/Models/ExpenseTest.php
@@ -22,6 +22,16 @@ it('casts and formats expense values and exposes relationships', function () {
         ->and($expense->recorder()->firstOrFail()->is($recorder))->toBeTrue();
 });
 
+it('formats expenses with the family currency', function () {
+    $family = Family::factory()->create(['currency' => 'QAR']);
+    $recorder = User::factory()->admin()->create(['family_id' => $family->id]);
+    $expense = Expense::factory()->recordedBy($recorder)->create([
+        'amount' => 12345,
+    ]);
+
+    expect($expense->formatted_amount)->toBe('QAR 12,345.00');
+});
+
 it('filters and orders expenses with local scopes', function () {
     $older = Expense::factory()->spentOn('2026-05-01 09:00:00')->create();
     $insideRange = Expense::factory()->spentOn('2026-05-10 09:00:00')->create();

--- a/tests/Feature/Models/FamilyCategoryTest.php
+++ b/tests/Feature/Models/FamilyCategoryTest.php
@@ -19,6 +19,18 @@ it('casts and formats family category amounts', function () {
         ->and($category->label_with_amount)->toBe("Adults (\u{20A6}4,500/month)");
 });
 
+it('formats family category amounts with the family currency', function () {
+    $family = Family::factory()->create(['currency' => 'QAR']);
+    $category = FamilyCategory::factory()->create([
+        'family_id' => $family->id,
+        'name' => 'Monthly Dues',
+        'monthly_amount' => 100,
+    ]);
+
+    expect($category->formatted_amount)->toBe('QAR 100')
+        ->and($category->label_with_amount)->toBe('Monthly Dues (QAR 100/month)');
+});
+
 it('exposes family and assigned user relationships', function () {
     $family = Family::factory()->create();
     $category = FamilyCategory::factory()->create(['family_id' => $family->id]);

--- a/tests/Feature/Models/FundAdjustmentTest.php
+++ b/tests/Feature/Models/FundAdjustmentTest.php
@@ -22,6 +22,16 @@ it('casts and formats fund adjustment values and exposes relationships', functio
         ->and($adjustment->recorder()->firstOrFail()->is($recorder))->toBeTrue();
 });
 
+it('formats fund adjustments with the family currency', function () {
+    $family = Family::factory()->create(['currency' => 'QAR']);
+    $recorder = User::factory()->admin()->create(['family_id' => $family->id]);
+    $adjustment = FundAdjustment::factory()->recordedBy($recorder)->create([
+        'amount' => 450,
+    ]);
+
+    expect($adjustment->formatted_amount)->toBe('QAR 450.00');
+});
+
 it('orders fund adjustments by latest first', function () {
     $older = FundAdjustment::factory()->create(['recorded_at' => '2026-05-01 09:00:00']);
     $newer = FundAdjustment::factory()->create(['recorded_at' => '2026-05-11 09:00:00']);

--- a/tests/Feature/Models/PaymentTest.php
+++ b/tests/Feature/Models/PaymentTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\Contribution;
+use App\Models\Family;
 use App\Models\Payment;
 use App\Models\User;
 use Carbon\Carbon;
@@ -46,6 +47,21 @@ it('returns empty helper values when no contribution is loaded', function () {
 
     expect($payment->getMember())->toBeNull()
         ->and($payment->getPeriodLabel())->toBe('');
+});
+
+it('formats payments with the contribution family currency', function () {
+    $family = Family::factory()->create(['currency' => 'QAR']);
+    $member = User::factory()->member()->employed()->create([
+        'family_id' => $family->id,
+    ]);
+    $contribution = Contribution::factory()
+        ->forUser($member)
+        ->create(['family_id' => $family->id]);
+    $payment = Payment::factory()
+        ->forContribution($contribution)
+        ->create(['amount' => 123456]);
+
+    expect($payment->formatted_amount)->toBe('QAR 123,456.00');
 });
 
 it('filters payments with local query scopes', function () {

--- a/tests/Feature/Payments/RecordPaymentTest.php
+++ b/tests/Feature/Payments/RecordPaymentTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Enums\PaymentStatus;
 use App\Models\Contribution;
 use App\Models\Family;
+use App\Models\FamilyCategory;
 use App\Models\Payment;
 use App\Models\User;
 use App\Services\PaymentAllocationService;
@@ -57,6 +58,65 @@ describe('Record Full Payment', function () {
             );
     });
 
+    it('financial secretary can view custom category members for recording payments', function () {
+        $family = Family::factory()->create(['currency' => 'QAR']);
+        $monthlyDues = FamilyCategory::factory()->create([
+            'family_id' => $family->id,
+            'name' => 'Monthly Dues',
+            'monthly_amount' => 100,
+        ]);
+        $financialSecretary = User::factory()->financialSecretary()->create([
+            'family_id' => $family->id,
+            'category' => null,
+        ]);
+        $member = User::factory()->member()->create([
+            'family_id' => $family->id,
+            'category' => null,
+            'family_category_id' => $monthlyDues->id,
+            'name' => 'Jamila Ladi Hussain',
+        ]);
+
+        $this->actingAs($financialSecretary)
+            ->get(route('payments.index'))
+            ->assertSuccessful()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Payments/Index')
+                ->has('members', 1)
+                ->where('members.0.id', $member->id)
+                ->where('members.0.category_label', 'Monthly Dues')
+                ->where('members.0.monthly_amount', 100)
+            );
+    });
+
+    it('uses the family currency and actual monthly amount on payment forms', function () {
+        $family = Family::factory()->create(['currency' => 'QAR']);
+        $monthlyDues = FamilyCategory::factory()->create([
+            'family_id' => $family->id,
+            'name' => 'Monthly Dues',
+            'monthly_amount' => 100,
+        ]);
+        $financialSecretary = User::factory()->financialSecretary()->create([
+            'family_id' => $family->id,
+            'category' => null,
+        ]);
+        $member = User::factory()->member()->create([
+            'family_id' => $family->id,
+            'category' => null,
+            'family_category_id' => $monthlyDues->id,
+        ]);
+
+        $this->actingAs($financialSecretary)
+            ->get(route('payments.create', $member))
+            ->assertSuccessful()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Payments/Create')
+                ->where('member.category_label', 'Monthly Dues')
+                ->where('category_amount', 100)
+                ->where('formatted_amount', 'QAR 100.00')
+                ->where('categories.0.label', 'Employed (QAR 4,000/month)')
+            );
+    });
+
     it('financial secretary can record a full payment', function () {
         $contribution = Contribution::factory()
             ->forUser($this->member)
@@ -80,6 +140,40 @@ describe('Record Full Payment', function () {
         ]);
 
         expect($contribution->refresh()->status)->toBe(PaymentStatus::Paid);
+    });
+
+    it('uses the family currency in the payment recorded flash message', function () {
+        $family = Family::factory()->create(['currency' => 'QAR']);
+        $monthlyDues = FamilyCategory::factory()->create([
+            'family_id' => $family->id,
+            'name' => 'Monthly Dues',
+            'monthly_amount' => 100,
+        ]);
+        $financialSecretary = User::factory()->financialSecretary()->create([
+            'family_id' => $family->id,
+        ]);
+        $member = User::factory()->member()->create([
+            'family_id' => $family->id,
+            'category' => null,
+            'family_category_id' => $monthlyDues->id,
+        ]);
+
+        Contribution::factory()
+            ->forUser($member)
+            ->currentMonth()
+            ->create([
+                'family_id' => $family->id,
+                'expected_amount' => 100,
+            ]);
+
+        $this->actingAs($financialSecretary)
+            ->post(route('payments.store'), [
+                'member_id' => $member->id,
+                'amount' => 100,
+                'paid_at' => now()->toDateString(),
+            ])
+            ->assertRedirect(route('dashboard'))
+            ->assertSessionHas('success', "Payment of QAR 100.00 recorded for {$member->name}.");
     });
 
     it('super admin can record a full payment', function () {


### PR DESCRIPTION
## Summary
- route family-facing Vue money displays through a shared currency formatter using the active family currency
- use family currency in backend formatted amounts, flash messages, model accessors, AI tool copy, and notification amounts
- treat custom family categories as payable members and prefer custom category labels such as Monthly Dues in payment/member/dashboard/report views

## Validation
- vendor/bin/pint --dirty --format agent
- npm run format:check
- npm run lint
- npm run build
- composer analyse
- php artisan test --compact tests/Feature/Payments/RecordPaymentTest.php tests/Feature/FundAdjustments/FundAdjustmentCrudTest.php tests/Feature/MemberPaymentTest.php tests/Feature/Reports/MonthlyReportTest.php tests/Feature/Dashboard/AdminDashboardTest.php tests/Feature/Models/ContributionTest.php tests/Feature/Models/ExpenseTest.php tests/Feature/Models/FamilyCategoryTest.php tests/Feature/Models/FundAdjustmentTest.php tests/Feature/Models/PaymentTest.php
- php artisan test --compact (`1022 passed`, `4506 assertions`)

Note: `npm run build` still prints existing Rolldown invalid annotation warnings from `reka-ui`/`@vueuse/core`, but exits successfully.