### PR TITLE
[codex] Fix production Livewire assets and Pay navigation

### DIFF
--- a/deployment/nginx/familyfunds.app.conf
+++ b/deployment/nginx/familyfunds.app.conf
@@ -60,6 +60,13 @@ server {
         try_files $uri =404;
     }
 
+    # Livewire v4 serves JavaScript, CSS, upload, and update endpoints through
+    # hashed Laravel routes such as /livewire-{hash}/livewire.min.js. This
+    # prefix must reach PHP before the generic static .js/.css rule below.
+    location ^~ /livewire- {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
     # Gzip compression
     gzip on;
     gzip_comp_level 5;

--- a/resources/js/lib/appNavigation.ts
+++ b/resources/js/lib/appNavigation.ts
@@ -69,9 +69,20 @@ export function useAppNavigation() {
     );
     const hasSubscriptionFeature = (feature: string) =>
         subscriptionFeatures.value.includes(feature);
+    const canRecordPayments = computed(
+        () => page.props.auth?.can?.record_payments === true,
+    );
+
+    const payItem = computed<NavItem>(() => ({
+        title: 'Pay',
+        href: payContributions(),
+        icon: CreditCard,
+        component: 'Pay/Index',
+        section: 'main',
+    }));
 
     const paymentItem = computed<NavItem>(() => {
-        if (page.props.auth?.can?.record_payments) {
+        if (canRecordPayments.value) {
             return {
                 title: 'Payments',
                 href: paymentsIndex(),
@@ -81,13 +92,7 @@ export function useAppNavigation() {
             };
         }
 
-        return {
-            title: 'Pay',
-            href: payContributions(),
-            icon: CreditCard,
-            component: 'Pay/Index',
-            section: 'main',
-        };
+        return payItem.value;
     });
 
     const primaryItems = computed<NavItem[]>(() => {
@@ -137,6 +142,10 @@ export function useAppNavigation() {
                 section: 'main',
             },
         ];
+
+        if (canRecordPayments.value) {
+            items.push(payItem.value);
+        }
 
         if (
             page.props.featureFlags?.ai_assistant &&

--- a/tests/Browser/MobileAppShellTest.php
+++ b/tests/Browser/MobileAppShellTest.php
@@ -198,6 +198,12 @@ describe('Mobile app shell', function () {
             ->assertSee('Dashboard')
             ->assertSee('Members')
             ->assertSee('Payments')
+            ->assertScript(<<<'JS'
+                () => Array.from(document.querySelectorAll('a')).some((link) => {
+                    return link.textContent?.trim() === 'Pay'
+                        && link.getAttribute('href')?.endsWith('/pay');
+                })
+            JS)
             ->assertSee('Family Admin')
             ->assertSee('Family Settings')
             ->assertNoJavaScriptErrors();
@@ -249,6 +255,12 @@ describe('Mobile app shell', function () {
         $page = visit("/{$this->family->slug}/dashboard");
 
         $page->assertSee('Platform Admin')
+            ->assertScript(<<<'JS'
+                () => Array.from(document.querySelectorAll('a')).some((link) => {
+                    return link.textContent?.trim() === 'Pay'
+                        && link.getAttribute('href')?.endsWith('/pay');
+                })
+            JS)
             ->click('Platform Admin')
             ->assertPathIs('/platform')
             ->assertSee('Platform Overview')

--- a/tests/Unit/DeploymentNginxConfigTest.php
+++ b/tests/Unit/DeploymentNginxConfigTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+it('passes Livewire hashed asset routes to Laravel before static asset handling', function () {
+    $contents = file_get_contents(__DIR__.'/../../deployment/nginx/familyfunds.app.conf');
+
+    if ($contents === false) {
+        throw new RuntimeException('Unable to read production Nginx configuration.');
+    }
+
+    $livewireLocation = strpos($contents, 'location ^~ /livewire-');
+    $staticAssetLocation = strpos($contents, 'location ~* \.(css|js|gif|ico|jpg|jpeg|png|svg|webp|woff|woff2|ttf|eot)$');
+
+    expect($livewireLocation)->not->toBeFalse()
+        ->and($staticAssetLocation)->not->toBeFalse()
+        ->and($contents)->toContain('location ^~ /livewire-')
+        ->and($contents)->toContain('try_files $uri $uri/ /index.php?$query_string;');
+
+    if ($livewireLocation === false || $staticAssetLocation === false) {
+        throw new RuntimeException('Expected production Nginx config to contain Livewire and static asset locations.');
+    }
+
+    expect($livewireLocation)->toBeLessThan($staticAssetLocation);
+});

--- a/tests/Unit/PwaConfigTest.php
+++ b/tests/Unit/PwaConfigTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+it('precaches the root offline fallback used by Workbox navigation handling', function () {
+    $contents = file_get_contents(__DIR__.'/../../vite.config.ts');
+
+    if ($contents === false) {
+        throw new RuntimeException('Unable to read Vite configuration.');
+    }
+
+    expect($contents)
+        ->toContain("url: '/offline.html'")
+        ->toContain('revision: CACHE_VERSION')
+        ->toContain("navigateFallback: '/offline.html'");
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,7 +46,6 @@ export default defineConfig({
                 'favicon.ico',
                 'favicon.svg',
                 'apple-touch-icon.png',
-                'offline.html',
             ],
             manifest: {
                 name: 'FamilyFunds',
@@ -120,6 +119,12 @@ export default defineConfig({
                 skipWaiting: true,
                 clientsClaim: true,
                 importScripts: ['/web-push-sw.js'],
+                additionalManifestEntries: [
+                    {
+                        url: '/offline.html',
+                        revision: CACHE_VERSION,
+                    },
+                ],
                 navigateFallback: '/offline.html',
                 navigateFallbackDenylist: [/^\/build\//, /^\/api\//],
                 runtimeCaching: [


### PR DESCRIPTION
## Summary

- Route Livewire v4 hashed asset paths through Laravel before the production nginx static `.js` rule.
- Precache `/offline.html` so Workbox navigation fallback does not throw `non-precached-url`.
- Keep `Payments` for payment-capable family users and also expose the self-pay `Pay` link.

## Why

Production `/platform` was loading Filament without Livewire because `/livewire-*/livewire.min.js` was intercepted by nginx static asset handling and returned 404. The PWA service worker also referenced `/offline.html` as a navigation fallback without including it in the generated precache.

For family navigation, users who could record payments only saw `Payments`, so a platform admin who also belongs to a family could not reach their own `Pay` flow from the main app navigation.

## Validation

- `vendor/bin/pint --dirty --format agent`
- `php artisan test --compact tests/Unit/DeploymentNginxConfigTest.php tests/Unit/PwaConfigTest.php`
- `php artisan test --compact tests/Browser/MobileAppShellTest.php`
- `composer analyse`
- `npm run lint`
- `npm run format:check`
- `npm run types:check`
- `npm run build`
- `git diff --check`
