### PR TITLE
Fix current-family Paystack initiation

### DIFF
--- a/app/Http/Controllers/MemberPaymentController.php
+++ b/app/Http/Controllers/MemberPaymentController.php
@@ -35,8 +35,10 @@ class MemberPaymentController extends Controller
     public function show(): Response
     {
         $user = $this->authUser();
+        $family = app(Family::class);
 
         $pendingContributions = $user->contributions()
+            ->where('family_id', $family->id)
             ->incomplete()
             ->oldestFirst()
             ->get()
@@ -51,7 +53,6 @@ class MemberPaymentController extends Controller
                 'period_label' => $contribution->period_label,
             ]);
 
-        $family = app(Family::class);
         $paystackPublicKey = $this->stringConfig('services.paystack.public_key');
         $bankSetupStatus = $this->bankSetupStatus($family, $paystackPublicKey);
 
@@ -73,9 +74,9 @@ class MemberPaymentController extends Controller
         $validated = $request->validated();
 
         $user = $this->authUser();
-        $family = $user->family;
+        $family = app(Family::class);
 
-        if (! $family instanceof Family || ! $family->hasBankDetails()) {
+        if (! $family->hasBankDetails()) {
             return response()->json([
                 'message' => 'Online payments are not set up for your family. Ask your admin to configure bank details.',
             ], 422);
@@ -85,6 +86,7 @@ class MemberPaymentController extends Controller
 
         // Calculate total from selected contributions
         $contributions = $user->contributions()
+            ->where('family_id', $family->id)
             ->whereIn('id', $contributionIds)
             ->incomplete()
             ->get();

--- a/resources/js/lib/familyRouteDefaults.ts
+++ b/resources/js/lib/familyRouteDefaults.ts
@@ -33,23 +33,17 @@ function pageSnapshot(): InertiaPageSnapshot | null {
 }
 
 export function currentFamilySlug(): string {
-    const pageFamilySlug = pageSnapshot()?.props?.family?.slug;
-
-    if (pageFamilySlug) {
-        return pageFamilySlug;
-    }
-
     if (typeof window === 'undefined') {
-        return '';
+        return pageSnapshot()?.props?.family?.slug ?? '';
     }
 
     const firstSegment = window.location.pathname.split('/').filter(Boolean)[0];
 
-    if (!firstSegment || reservedGlobalSegments.has(firstSegment)) {
-        return '';
+    if (firstSegment && !reservedGlobalSegments.has(firstSegment)) {
+        return decodeURIComponent(firstSegment);
     }
 
-    return decodeURIComponent(firstSegment);
+    return pageSnapshot()?.props?.family?.slug ?? '';
 }
 
 export function initializeFamilyRouteDefaults(): void {

--- a/tests/Feature/MemberPaymentTest.php
+++ b/tests/Feature/MemberPaymentTest.php
@@ -148,6 +148,37 @@ it('marks online payments as ready when bank details and paystack key are config
         );
 });
 
+it('only shows pending contributions for the current family', function () {
+    $legacyFamily = Family::factory()->create();
+    $currentFamily = Family::factory()->create([
+        'bank_name' => 'Guaranty Trust Bank',
+        'bank_code' => '058',
+        'account_number' => '0045502216',
+    ]);
+    $member = User::factory()->member()->create(['family_id' => $legacyFamily->id]);
+    $member->ensureFamilyMembership($currentFamily);
+
+    Contribution::factory()->create([
+        'family_id' => $legacyFamily->id,
+        'user_id' => $member->id,
+        'expected_amount' => 4000,
+    ]);
+    $currentContribution = Contribution::factory()->create([
+        'family_id' => $currentFamily->id,
+        'user_id' => $member->id,
+        'expected_amount' => 4000,
+    ]);
+
+    $this->actingAs($member)
+        ->get(route('pay.index', ['current_family' => $currentFamily->slug]))
+        ->assertSuccessful()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('Pay/Index')
+            ->has('pending_contributions', 1)
+            ->where('pending_contributions.0.id', $currentContribution->id)
+        );
+});
+
 it('redirects guests from pay page', function () {
     $this->get(route('pay.index'))
         ->assertRedirect();
@@ -334,6 +365,42 @@ it('rejects initiation when no unpaid contributions are selected', function () {
         ])
         ->assertUnprocessable()
         ->assertJson(['message' => 'No unpaid contributions selected.']);
+});
+
+it('rejects initiation with contribution ids from another family', function () {
+    Http::fake([
+        'api.paystack.co/transaction/initialize' => Http::response([
+            'status' => true,
+            'data' => [
+                'authorization_url' => 'https://checkout.paystack.com/test',
+                'access_code' => 'access_test',
+                'reference' => 'TXN_TEST123',
+            ],
+        ]),
+    ]);
+
+    $legacyFamily = Family::factory()->create();
+    $currentFamily = Family::factory()->create([
+        'bank_name' => 'Kuda Bank',
+        'bank_code' => '090267',
+        'account_number' => '1234567890',
+    ]);
+    $member = User::factory()->member()->create(['family_id' => $legacyFamily->id]);
+    $member->ensureFamilyMembership($currentFamily);
+    $legacyContribution = Contribution::factory()->create([
+        'family_id' => $legacyFamily->id,
+        'user_id' => $member->id,
+        'expected_amount' => 4000,
+    ]);
+
+    $this->actingAs($member)
+        ->postJson(route('pay.initiate', ['current_family' => $currentFamily->slug]), [
+            'contribution_ids' => [$legacyContribution->id],
+        ])
+        ->assertUnprocessable()
+        ->assertJson(['message' => 'No unpaid contributions selected.']);
+
+    Http::assertNothingSent();
 });
 
 it('rejects initiation when selected contributions have no balance', function () {


### PR DESCRIPTION
## Summary
- use the bound current family when rendering and initiating member Paystack payments
- scope pending and selected contributions to the current family
- prefer the visible family URL segment for PWA route defaults to avoid stale history-state POSTs

## Verification
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Feature/MemberPaymentTest.php
- composer analyse
- npm run lint:check
- npm run types:check
- npm run build
- php artisan test --coverage --min=100 --compact