### PR TITLE
Promote dev to main

### DIFF
--- a/app/Notifications/ContributionReminderNotification.php
+++ b/app/Notifications/ContributionReminderNotification.php
@@ -117,6 +117,9 @@ class ContributionReminderNotification extends Notification implements ShouldQue
             ->subject($subject)
             ->markdown('mail.contribution-reminder', [
                 'contribution' => $this->contribution,
+                'contributionsUrl' => route('contributions.my', [
+                    'current_family' => $this->familySlug(),
+                ]),
                 'type' => $this->type,
                 'userName' => $this->notifiableName($notifiable),
                 'familyName' => $this->familyName(),

--- a/resources/views/mail/contribution-reminder.blade.php
+++ b/resources/views/mail/contribution-reminder.blade.php
@@ -19,7 +19,7 @@ This is a friendly reminder that your **{{ $contribution->period_label }}** cont
 | **Remaining Balance** | {{ $contribution->formattedBalance() }} |
 | **Due Date** | {{ $contribution->due_date->toFormattedDateString() }} |
 
-<x-mail::button :url="route('contributions.my')">
+<x-mail::button :url="$contributionsUrl">
 View My Contributions
 </x-mail::button>
 

--- a/tests/Feature/Notifications/ContributionReminderNotificationTest.php
+++ b/tests/Feature/Notifications/ContributionReminderNotificationTest.php
@@ -11,6 +11,7 @@ use App\Models\User;
 use App\Notifications\ContributionReminderNotification;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Queue\Middleware\RateLimited;
+use Illuminate\Support\Facades\URL;
 use NotificationChannels\WebPush\WebPushChannel;
 use NotificationChannels\WebPush\WebPushMessage;
 
@@ -74,6 +75,19 @@ describe('ContributionReminderNotification', function () {
         expect($mail)->toBeInstanceOf(MailMessage::class)
             ->and($mail->subject)->toContain('Reminder')
             ->and($mail->subject)->toContain($contribution->period_label);
+    });
+
+    it('renders mail with an explicit family-scoped contributions link', function () {
+        $family = Family::factory()->create(['slug' => 'smith-family']);
+        $user = User::factory()->member()->employed()->create(['family_id' => $family->id]);
+        $contribution = Contribution::factory()->forUser($user)->currentMonth()->create();
+
+        URL::defaults([]);
+
+        $mail = (new ContributionReminderNotification($contribution, 'reminder'))->toMail($user);
+
+        expect((string) $mail->render())
+            ->toContain(route('contributions.my', ['current_family' => $family->slug]));
     });
 
     it('builds correct mail content for follow_up type', function () {


### PR DESCRIPTION
## Summary

- Promotes `dev` to `main`.
- Includes #206, fixing contribution reminder email route generation for Nightwatch production issue #25.

## Verification

From #206:
- `php artisan test --compact tests/Feature/Notifications/ContributionReminderNotificationTest.php`
- `vendor/bin/pint --dirty --format agent`
- `git diff --check`

## Compare

- https://github.com/hussain4real/contribution-tracker/compare/main...dev