### PR TITLE
Fix nullable auth user SSR crash

### DIFF
--- a/resources/js/components/AppHeader.vue
+++ b/resources/js/components/AppHeader.vue
@@ -47,7 +47,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const page = usePage();
 const auth = computed(() => page.props.auth);
-const user = computed(() => auth.value.user);
+const user = computed(() => auth.value?.user ?? null);
 
 const isCurrentRoute = computed(
     () => (url: NonNullable<InertiaLinkProps['href']>) =>

--- a/resources/js/components/NavUser.vue
+++ b/resources/js/components/NavUser.vue
@@ -17,7 +17,7 @@ import { computed } from 'vue';
 import UserMenuContent from './UserMenuContent.vue';
 
 const page = usePage();
-const user = computed(() => page.props.auth.user);
+const user = computed(() => page.props.auth?.user ?? null);
 const { isMobile, state } = useSidebar();
 </script>
 

--- a/resources/js/components/UserInfo.vue
+++ b/resources/js/components/UserInfo.vue
@@ -5,7 +5,7 @@ import type { User } from '@/types';
 import { computed } from 'vue';
 
 interface Props {
-    user: User;
+    user: User | null;
     showEmail?: boolean;
 }
 
@@ -15,24 +15,22 @@ const props = withDefaults(defineProps<Props>(), {
 
 const { getInitials } = useInitials();
 
-// Compute whether we should show the avatar image
-const showAvatar = computed(
-    () => props.user.avatar && props.user.avatar !== '',
-);
+const displayName = computed(() => props.user?.name ?? 'Guest');
+const showAvatar = computed(() => !!props.user?.avatar);
 </script>
 
 <template>
     <Avatar class="h-8 w-8 overflow-hidden rounded-lg">
-        <AvatarImage v-if="showAvatar" :src="user.avatar!" :alt="user.name" />
+        <AvatarImage v-if="showAvatar" :src="user?.avatar" :alt="displayName" />
         <AvatarFallback class="rounded-lg text-black dark:text-white">
-            {{ getInitials(user.name) }}
+            {{ getInitials(displayName) }}
         </AvatarFallback>
     </Avatar>
 
     <div class="grid flex-1 text-left text-sm leading-tight">
-        <span class="truncate font-medium">{{ user.name }}</span>
+        <span class="truncate font-medium">{{ displayName }}</span>
         <span v-if="showEmail" class="truncate text-xs text-muted-foreground">{{
-            user.email
+            user?.email
         }}</span>
     </div>
 </template>

--- a/tests/Browser/SettingsPasswordFlowTest.php
+++ b/tests/Browser/SettingsPasswordFlowTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\User;
+
+describe('Settings password flow', function () {
+    beforeEach(function () {
+        $this->user = User::factory()->create([
+            'email' => 'settings-password@test.com',
+            'password' => bcrypt('password'),
+        ]);
+    });
+
+    it('renders the password settings page without JavaScript errors', function () {
+        $page = visit('/login');
+
+        $page->fill('email', 'settings-password@test.com')
+            ->fill('password', 'password')
+            ->click('Log in')
+            ->navigate(route('security.edit'))
+            ->assertSee('Update password')
+            ->assertNoJavaScriptErrors();
+    });
+});

--- a/tests/Browser/SettingsPasswordFlowTest.php
+++ b/tests/Browser/SettingsPasswordFlowTest.php
@@ -1,22 +1,31 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Models\User;
 
 describe('Settings password flow', function () {
     beforeEach(function () {
-        $this->user = User::factory()->create([
+        $this->user = User::factory()->withoutTwoFactor()->create([
             'email' => 'settings-password@test.com',
             'password' => bcrypt('password'),
         ]);
     });
 
     it('renders the password settings page without JavaScript errors', function () {
+        $passwordConfirmPath = parse_url(route('password.confirm'), PHP_URL_PATH) ?: '/user/confirm-password';
+        $securitySettingsPath = parse_url(route('security.edit'), PHP_URL_PATH) ?: '/settings/security';
+
         $page = visit('/login');
 
         $page->fill('email', 'settings-password@test.com')
             ->fill('password', 'password')
             ->click('Log in')
             ->navigate(route('security.edit'))
+            ->assertPathIs($passwordConfirmPath)
+            ->fill('password', 'password')
+            ->click('@confirm-password-button')
+            ->assertPathIs($securitySettingsPath)
             ->assertSee('Update password')
             ->assertNoJavaScriptErrors();
     });

--- a/tests/Feature/Settings/PasswordUpdateTest.php
+++ b/tests/Feature/Settings/PasswordUpdateTest.php
@@ -18,6 +18,7 @@ test('security settings page is displayed', function () {
         ->assertOk()
         ->assertInertia(fn (Assert $page) => $page
             ->component('settings/Security')
+            ->where('auth.user.id', $user->id)
             ->has('passkeys')
         );
 });


### PR DESCRIPTION
## Summary

- Fixes nullable shared auth user handling in sidebar/header user menu components.
- Makes UserInfo defensive so SSR cannot crash when auth.user is null.
- Adds settings password feature coverage and a browser smoke test for JavaScript errors.

Closes #208

## Verification

- php artisan test --compact tests/Feature/Settings/PasswordUpdateTest.php tests/Browser/SettingsPasswordFlowTest.php
- npm run build
- npm run lint
- vendor/bin/pint --dirty --format agent