### PR TITLE
Handle invalid HTTP method override probes

### DIFF
--- a/app/Http/HttpMethodOverrideSanitizer.php
+++ b/app/Http/HttpMethodOverrideSanitizer.php
@@ -31,7 +31,7 @@ final class HttpMethodOverrideSanitizer
     }
 
     /**
-     * @param  array<string, mixed>  $input
+     * @param  array<mixed>  $input
      */
     private static function sanitizeInputBag(array &$input): void
     {

--- a/app/Http/HttpMethodOverrideSanitizer.php
+++ b/app/Http/HttpMethodOverrideSanitizer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http;
 
 final class HttpMethodOverrideSanitizer

--- a/app/Http/HttpMethodOverrideSanitizer.php
+++ b/app/Http/HttpMethodOverrideSanitizer.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http;
+
+final class HttpMethodOverrideSanitizer
+{
+    /**
+     * @var array<int, string>
+     */
+    private const SupportedMethodOverrides = [
+        'DELETE',
+        'OPTIONS',
+        'PATCH',
+        'PUT',
+    ];
+
+    /**
+     * Remove unsupported HTTP method override input before the request is captured.
+     */
+    public static function sanitizeGlobals(): void
+    {
+        self::sanitizeInputBag($_POST);
+        self::sanitizeInputBag($_GET);
+        self::sanitizeInputBag($_REQUEST);
+
+        if (! self::isSupported($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] ?? null)) {
+            unset($_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE']);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    private static function sanitizeInputBag(array &$input): void
+    {
+        if (! array_key_exists('_method', $input)) {
+            return;
+        }
+
+        if (! self::isSupported($input['_method'])) {
+            unset($input['_method']);
+        }
+    }
+
+    private static function isSupported(mixed $method): bool
+    {
+        if (! is_string($method)) {
+            return false;
+        }
+
+        return in_array(strtoupper($method), self::SupportedMethodOverrides, true);
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\HttpMethodOverrideSanitizer;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 
@@ -18,5 +19,7 @@ require __DIR__.'/../vendor/autoload.php';
 // Bootstrap Laravel and handle the request...
 /** @var Application $app */
 $app = require_once __DIR__.'/../bootstrap/app.php';
+
+HttpMethodOverrideSanitizer::sanitizeGlobals();
 
 $app->handleRequest(Request::capture());

--- a/tests/Unit/HttpMethodOverrideSanitizerTest.php
+++ b/tests/Unit/HttpMethodOverrideSanitizerTest.php
@@ -6,11 +6,18 @@ use App\Http\HttpMethodOverrideSanitizer;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 
+beforeEach(function () {
+    $this->originalGet = $_GET;
+    $this->originalPost = $_POST;
+    $this->originalRequest = $_REQUEST;
+    $this->originalServer = $_SERVER;
+});
+
 afterEach(function () {
-    $_GET = [];
-    $_POST = [];
-    $_REQUEST = [];
-    $_SERVER = [];
+    $_GET = $this->originalGet;
+    $_POST = $this->originalPost;
+    $_REQUEST = $this->originalRequest;
+    $_SERVER = $this->originalServer;
 });
 
 it('removes unsupported form method overrides before the request is captured', function () {

--- a/tests/Unit/HttpMethodOverrideSanitizerTest.php
+++ b/tests/Unit/HttpMethodOverrideSanitizerTest.php
@@ -6,18 +6,22 @@ use App\Http\HttpMethodOverrideSanitizer;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 
-beforeEach(function () {
-    $this->originalGet = $_GET;
-    $this->originalPost = $_POST;
-    $this->originalRequest = $_REQUEST;
-    $this->originalServer = $_SERVER;
+$originalGlobals = [];
+
+beforeEach(function () use (&$originalGlobals) {
+    $originalGlobals = [
+        'get' => $_GET,
+        'post' => $_POST,
+        'request' => $_REQUEST,
+        'server' => $_SERVER,
+    ];
 });
 
-afterEach(function () {
-    $_GET = $this->originalGet;
-    $_POST = $this->originalPost;
-    $_REQUEST = $this->originalRequest;
-    $_SERVER = $this->originalServer;
+afterEach(function () use (&$originalGlobals) {
+    $_GET = $originalGlobals['get'];
+    $_POST = $originalGlobals['post'];
+    $_REQUEST = $originalGlobals['request'];
+    $_SERVER = $originalGlobals['server'];
 });
 
 it('removes unsupported form method overrides before the request is captured', function () {

--- a/tests/Unit/HttpMethodOverrideSanitizerTest.php
+++ b/tests/Unit/HttpMethodOverrideSanitizerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Http\HttpMethodOverrideSanitizer;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;

--- a/tests/Unit/HttpMethodOverrideSanitizerTest.php
+++ b/tests/Unit/HttpMethodOverrideSanitizerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Http\HttpMethodOverrideSanitizer;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
+
+afterEach(function () {
+    $_GET = [];
+    $_POST = [];
+    $_REQUEST = [];
+    $_SERVER = [];
+});
+
+it('removes unsupported form method overrides before the request is captured', function () {
+    $_SERVER['REQUEST_METHOD'] = 'POST';
+    $_POST['_method'] = 'PUT /index.php?s=captcha';
+    $_REQUEST['_method'] = $_POST['_method'];
+
+    expect(fn () => Request::capture()->getMethod())
+        ->toThrow(SuspiciousOperationException::class);
+
+    $_POST['_method'] = 'PUT /index.php?s=captcha';
+    $_REQUEST['_method'] = $_POST['_method'];
+
+    HttpMethodOverrideSanitizer::sanitizeGlobals();
+
+    expect($_POST)->not->toHaveKey('_method')
+        ->and($_REQUEST)->not->toHaveKey('_method')
+        ->and(Request::capture()->getMethod())->toBe('POST');
+});
+
+it('removes alphabetic but unsupported form method overrides before the request is captured', function () {
+    $_SERVER['REQUEST_METHOD'] = 'POST';
+    $_POST['_method'] = 'CAPTCHA';
+    $_REQUEST['_method'] = $_POST['_method'];
+
+    HttpMethodOverrideSanitizer::sanitizeGlobals();
+
+    expect($_POST)->not->toHaveKey('_method')
+        ->and($_REQUEST)->not->toHaveKey('_method')
+        ->and(Request::capture()->getMethod())->toBe('POST');
+});
+
+it('preserves valid form method overrides', function () {
+    $_SERVER['REQUEST_METHOD'] = 'POST';
+    $_POST['_method'] = 'PATCH';
+    $_REQUEST['_method'] = $_POST['_method'];
+
+    HttpMethodOverrideSanitizer::sanitizeGlobals();
+
+    expect($_POST['_method'])->toBe('PATCH')
+        ->and(Request::capture()->getMethod())->toBe('PATCH');
+});
+
+it('removes unsupported header method overrides before the request is captured', function () {
+    $_SERVER['REQUEST_METHOD'] = 'POST';
+    $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'PATCH /admin';
+
+    expect(fn () => Request::capture()->getMethod())
+        ->toThrow(SuspiciousOperationException::class);
+
+    $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'PATCH /admin';
+
+    HttpMethodOverrideSanitizer::sanitizeGlobals();
+
+    expect($_SERVER)->not->toHaveKey('HTTP_X_HTTP_METHOD_OVERRIDE')
+        ->and(Request::capture()->getMethod())->toBe('POST');
+});


### PR DESCRIPTION
## Summary

- Closes #211
- Adds a pre-capture HTTP method override sanitizer before Laravel creates the request
- Preserves normal Laravel spoofed methods: `PUT`, `PATCH`, `DELETE`, and `OPTIONS`
- Strips malformed or unsupported `_method` and `X-HTTP-METHOD-OVERRIDE` probe values before Nightwatch inspects the request

## Nightwatch

- App: familyfunds (`a1529fa7-7bf5-4e44-b387-c66aff4a08b6`)
- Environment: Production (`a1529fa7-7ff6-403c-ab13-cebac05b258d`, eu-central-1)
- Nightwatch issue: #26
- Exception: `Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException: Invalid HTTP method override.`
- Last seen: 2026-07-01T16:56:26+00:00
- Occurrences: 1 in 7 days, 0 in 24 hours
- Users affected: 0

## Verification

- `vendor/bin/pint --dirty --format agent`
- `/private/tmp/contribution-tracker-nightwatch`: `composer dump-autoload --no-interaction`
- `/private/tmp/contribution-tracker-nightwatch`: `php artisan test --compact tests/Unit/HttpMethodOverrideSanitizerTest.php`

Note: the numeric Codex worktree path triggers Pest generated-namespace failures for this test file, so the focused Pest verification was run from a physical `/private/tmp` copy with the same branch contents.