### PR TITLE
Require production backup archive password

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,8 +12,10 @@ use App\Http\Responses\TwoFactorLoginResponse;
 use App\Http\Responses\VerifyEmailResponse;
 use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\LazyLoadingViolationException;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
@@ -27,6 +29,7 @@ use Laravel\Fortify\Http\Responses\RedirectAsIntended;
 use Laravel\Passkeys\Contracts\PasskeyLoginResponse as PasskeyLoginResponseContract;
 use Laravel\Passport\Passport;
 use Laravel\Pennant\Middleware\EnsureFeaturesAreActive;
+use RuntimeException;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -47,6 +50,8 @@ class AppServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        $this->requireEncryptedProductionBackups();
+
         // Gate for generating reports
         Gate::define('generate-reports', function (User $user) {
             return $user->activeRole()->canGenerateReports();
@@ -94,6 +99,27 @@ class AppServiceProvider extends ServiceProvider
             } else {
                 throw new LazyLoadingViolationException($model, $relation);
             }
+        });
+    }
+
+    private function requireEncryptedProductionBackups(): void
+    {
+        Event::listen(CommandStarting::class, function (CommandStarting $event): void {
+            if (! $this->app->isProduction()) {
+                return;
+            }
+
+            if (! in_array($event->command, ['backup:run', 'backups:sync-google-drive'], true)) {
+                return;
+            }
+
+            $password = config('backup.backup.password');
+
+            if (is_string($password) && trim($password) !== '') {
+                return;
+            }
+
+            throw new RuntimeException('BACKUP_ARCHIVE_PASSWORD is required before production backups can run.');
         });
     }
 }

--- a/tests/Feature/Providers/AppServiceProviderTest.php
+++ b/tests/Feature/Providers/AppServiceProviderTest.php
@@ -6,10 +6,14 @@ use App\Models\User;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\LazyLoadingViolationException;
+use Illuminate\Foundation\Testing\WithConsoleEvents;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\View\View;
 use Laravel\Passport\Contracts\AuthorizationViewResponse;
+
+uses(WithConsoleEvents::class);
 
 it('configures the whatsapp notification rate limiter', function () {
     config(['services.whatsapp.rate_limit_per_minute' => 0]);
@@ -74,6 +78,57 @@ it('throws lazy loading violations outside production', function () {
     Model::preventLazyLoading(false);
     Model::automaticallyEagerLoadRelationships();
 });
+
+it('does not require a backup archive password outside production', function () {
+    config()->set('backup.backup.password', '');
+    config()->set('backup.google_drive.enabled', false);
+
+    $exitCode = Artisan::call('backups:sync-google-drive');
+
+    expect($exitCode)->toBe(1)
+        ->and(Artisan::output())->toContain('Google Drive backup sync is disabled.');
+});
+
+it('does not require a backup archive password for unrelated production commands', function () {
+    app()->detectEnvironment(fn (): string => 'production');
+    config()->set('backup.backup.password', '');
+
+    try {
+        expect(Artisan::call('inspire'))->toBe(0);
+    } finally {
+        app()->detectEnvironment(fn (): string => 'testing');
+    }
+});
+
+it('allows production backup commands when the archive password is configured', function () {
+    app()->detectEnvironment(fn (): string => 'production');
+    config()->set('backup.backup.password', 'configured-secret');
+    config()->set('backup.google_drive.enabled', false);
+
+    try {
+        $exitCode = Artisan::call('backups:sync-google-drive');
+
+        expect($exitCode)->toBe(1)
+            ->and(Artisan::output())->toContain('Google Drive backup sync is disabled.');
+    } finally {
+        app()->detectEnvironment(fn (): string => 'testing');
+    }
+});
+
+it('requires a backup archive password before production backup commands run', function (string $command, array $parameters) {
+    app()->detectEnvironment(fn (): string => 'production');
+    config()->set('backup.backup.password', '');
+
+    try {
+        expect(fn () => Artisan::call($command, $parameters))
+            ->toThrow(RuntimeException::class, 'BACKUP_ARCHIVE_PASSWORD is required before production backups can run.');
+    } finally {
+        app()->detectEnvironment(fn (): string => 'testing');
+    }
+})->with([
+    'local backup run' => ['backup:run', ['--only-to-disk' => 'local', '--disable-notifications' => true]],
+    'google drive sync' => ['backups:sync-google-drive', []],
+]);
 
 it('logs lazy loading violations in production', function () {
     app()->detectEnvironment(fn (): string => 'production');


### PR DESCRIPTION
## Summary
- block production backup and Google Drive sync commands when BACKUP_ARCHIVE_PASSWORD is blank
- cover the guard with console-event provider tests

## Verification
- php artisan test --compact tests/Feature/Providers/AppServiceProviderTest.php tests/Feature/BackupGoogleDriveSyncTest.php
- vendor/bin/pint --dirty --format agent
- composer ci:check

Addresses review feedback from #215.