### PR TITLE
Keep disabled backup notifications configured

### DIFF
--- a/config/backup.php
+++ b/config/backup.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 use Spatie\Backup\Notifications\Notifiable;
 use Spatie\Backup\Notifications\Notifications\BackupHasFailedNotification;
+use Spatie\Backup\Notifications\Notifications\BackupWasSuccessfulNotification;
 use Spatie\Backup\Notifications\Notifications\CleanupHasFailedNotification;
+use Spatie\Backup\Notifications\Notifications\CleanupWasSuccessfulNotification;
+use Spatie\Backup\Notifications\Notifications\HealthyBackupWasFoundNotification;
 use Spatie\Backup\Notifications\Notifications\UnhealthyBackupWasFoundNotification;
 use Spatie\Backup\Tasks\Cleanup\Strategies\DefaultStrategy;
 use Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays;
@@ -235,8 +238,11 @@ return [
     'notifications' => [
         'notifications' => [
             BackupHasFailedNotification::class => ['mail'],
+            BackupWasSuccessfulNotification::class => [],
             UnhealthyBackupWasFoundNotification::class => ['mail'],
+            HealthyBackupWasFoundNotification::class => [],
             CleanupHasFailedNotification::class => ['mail'],
+            CleanupWasSuccessfulNotification::class => [],
         ],
 
         /*

--- a/tests/Feature/BackupConfigurationTest.php
+++ b/tests/Feature/BackupConfigurationTest.php
@@ -69,15 +69,20 @@ test('backup retention keeps fourteen daily backups with weekly and monthly hist
 test('backup notifications are failure only', function () {
     $notifications = config('backup.notifications.notifications');
 
+    if (! is_array($notifications)) {
+        throw new RuntimeException('Expected backup notifications config to be an array.');
+    }
+
     expect($notifications)->toHaveKeys([
         BackupHasFailedNotification::class,
-        CleanupHasFailedNotification::class,
-        UnhealthyBackupWasFoundNotification::class,
-    ])->and($notifications)->not->toHaveKeys([
         BackupWasSuccessfulNotification::class,
+        CleanupHasFailedNotification::class,
         CleanupWasSuccessfulNotification::class,
         HealthyBackupWasFoundNotification::class,
-    ]);
+        UnhealthyBackupWasFoundNotification::class,
+    ])->and($notifications[BackupWasSuccessfulNotification::class])->toBe([])
+        ->and($notifications[CleanupWasSuccessfulNotification::class])->toBe([])
+        ->and($notifications[HealthyBackupWasFoundNotification::class])->toBe([]);
 });
 
 test('backup scheduler runs production backup workflow in qatar time', function () {


### PR DESCRIPTION
Fixes the Spatie backup monitor failure found after the #216 deploy by keeping success notification classes configured with empty channel arrays. This preserves failure-only notifications while allowing backup:monitor to resolve HealthyBackupWasFoundNotification without an undefined-array-key error.\n\nVerified locally:\n- php artisan test --compact tests/Feature/BackupConfigurationTest.php tests/Feature/Providers/AppServiceProviderTest.php\n- vendor/bin/pint --dirty --format agent\n- composer ci:check