### PR TITLE
Fix Phase 3 review findings

### DIFF
--- a/app/Http/Controllers/ReportScheduleController.php
+++ b/app/Http/Controllers/ReportScheduleController.php
@@ -10,6 +10,7 @@ use App\Enums\ReportType;
 use App\Http\Requests\StoreReportScheduleRequest;
 use App\Models\Family;
 use App\Models\ReportSchedule;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
@@ -22,6 +23,9 @@ class ReportScheduleController extends Controller
         abort_unless($family instanceof Family, 403);
 
         $validated = $request->validated();
+        $timezone = $request->string('timezone')->toString();
+        $nextRunAt = CarbonImmutable::parse($request->string('next_run_at')->toString(), $timezone)->utc();
+
         $family->reportSchedules()->create([
             'created_by' => $user->id,
             'name' => is_string($validated['name']) ? $validated['name'] : '',
@@ -31,8 +35,8 @@ class ReportScheduleController extends Controller
             'channels' => is_array($validated['channels']) ? array_values(array_filter($validated['channels'], 'is_string')) : [],
             'recipients' => is_array($validated['recipients']) ? array_values(array_filter($validated['recipients'], 'is_string')) : [],
             'frequency' => ReportScheduleFrequency::from(is_string($validated['frequency']) ? $validated['frequency'] : ''),
-            'timezone' => is_string($validated['timezone']) ? $validated['timezone'] : 'UTC',
-            'next_run_at' => is_string($validated['next_run_at']) ? $validated['next_run_at'] : now(),
+            'timezone' => $timezone,
+            'next_run_at' => $nextRunAt,
             'is_active' => true,
         ]);
 

--- a/app/Http/Requests/StoreReportScheduleRequest.php
+++ b/app/Http/Requests/StoreReportScheduleRequest.php
@@ -7,8 +7,12 @@ namespace App\Http\Requests;
 use App\Enums\ReportFormat;
 use App\Enums\ReportScheduleFrequency;
 use App\Enums\ReportType;
+use App\Models\Family;
+use App\Models\User;
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class StoreReportScheduleRequest extends FormRequest
 {
@@ -20,6 +24,9 @@ class StoreReportScheduleRequest extends FormRequest
     /** @return array<string, mixed> */
     public function rules(): array
     {
+        $user = $this->user();
+        $family = $user instanceof User ? ($user->currentFamily ?? $user->family) : null;
+
         return [
             'name' => ['required', 'string', 'max:120'],
             'report_type' => ['required', Rule::enum(ReportType::class)],
@@ -27,14 +34,36 @@ class StoreReportScheduleRequest extends FormRequest
             'filters' => ['required', 'array'],
             'filters.date_from' => ['required', 'date_format:Y-m-d'],
             'filters.date_to' => ['required', 'date_format:Y-m-d', 'after_or_equal:filters.date_from'],
-            'filters.member_id' => ['nullable', 'integer'],
+            'filters.member_id' => [
+                'nullable',
+                Rule::requiredIf($this->input('report_type') === ReportType::MemberStatement->value),
+                'integer',
+                Rule::exists('family_members', 'user_id')->where('family_id', $family instanceof Family ? $family->id : 0),
+            ],
             'channels' => ['required', 'array', 'min:1'],
             'channels.*' => ['required', Rule::in(['email', 'whatsapp'])],
             'recipients' => ['required', 'array', 'min:1'],
             'recipients.*' => ['required', 'string', 'max:190'],
             'frequency' => ['required', Rule::enum(ReportScheduleFrequency::class)],
             'timezone' => ['required', 'timezone'],
-            'next_run_at' => ['required', 'date', 'after_or_equal:now'],
+            'next_run_at' => ['required', 'date'],
         ];
+    }
+
+    /** @return array<int, callable(Validator): void> */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            if ($validator->errors()->hasAny(['timezone', 'next_run_at'])) {
+                return;
+            }
+
+            $timezone = $this->string('timezone')->toString();
+            $nextRunAt = $this->string('next_run_at')->toString();
+
+            if (CarbonImmutable::parse($nextRunAt, $timezone)->isBefore(now())) {
+                $validator->errors()->add('next_run_at', 'The next run at field must be a date after or equal to now.');
+            }
+        }];
     }
 }

--- a/app/Jobs/ProcessPaystackWebhook.php
+++ b/app/Jobs/ProcessPaystackWebhook.php
@@ -28,7 +28,11 @@ class ProcessPaystackWebhook implements ShouldBeUnique, ShouldQueue
     public function uniqueId(): string
     {
         $data = is_array($this->payload['data'] ?? null) ? $this->payload['data'] : [];
-        $reference = $data['reference'] ?? $data['subscription_code'] ?? '';
+        $subscription = is_array($data['subscription'] ?? null) ? $data['subscription'] : [];
+        $reference = $data['reference']
+            ?? $data['subscription_code']
+            ?? $subscription['subscription_code']
+            ?? '';
         $event = $this->payload['event'] ?? '';
 
         return hash(

--- a/app/Policies/ExpensePolicy.php
+++ b/app/Policies/ExpensePolicy.php
@@ -17,7 +17,8 @@ class ExpensePolicy
 
     public function view(User $user, Expense $expense): bool
     {
-        return $user->membershipForFamilyId($expense->family_id) !== null;
+        return ($user->current_family_id ?? $user->family_id) === $expense->family_id
+            && $user->membershipForFamilyId($expense->family_id) !== null;
     }
 
     public function create(User $user): bool
@@ -32,7 +33,8 @@ class ExpensePolicy
 
     public function delete(User $user, Expense $expense): bool
     {
-        return $user->membershipForFamilyId($expense->family_id)?->role === Role::Admin;
+        return ($user->current_family_id ?? $user->family_id) === $expense->family_id
+            && $user->membershipForFamilyId($expense->family_id)?->role === Role::Admin;
     }
 
     public function restore(User $user, Expense $expense): bool

--- a/app/Policies/ExpensePolicy.php
+++ b/app/Policies/ExpensePolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Enums\Role;
 use App\Models\Expense;
 use App\Models\User;
 
@@ -31,7 +32,7 @@ class ExpensePolicy
 
     public function delete(User $user, Expense $expense): bool
     {
-        return $user->isAdmin() && $user->membershipForFamilyId($expense->family_id) !== null;
+        return $user->membershipForFamilyId($expense->family_id)?->role === Role::Admin;
     }
 
     public function restore(User $user, Expense $expense): bool

--- a/app/Policies/FundAdjustmentPolicy.php
+++ b/app/Policies/FundAdjustmentPolicy.php
@@ -31,7 +31,7 @@ class FundAdjustmentPolicy
 
     public function delete(User $user, FundAdjustment $fundAdjustment): bool
     {
-        return $user->canRecordPayments() && $user->membershipForFamilyId($fundAdjustment->family_id) !== null;
+        return $user->membershipForFamilyId($fundAdjustment->family_id)?->role->canRecordPayments() === true;
     }
 
     public function restore(User $user, FundAdjustment $fundAdjustment): bool

--- a/app/Policies/FundAdjustmentPolicy.php
+++ b/app/Policies/FundAdjustmentPolicy.php
@@ -16,7 +16,8 @@ class FundAdjustmentPolicy
 
     public function view(User $user, FundAdjustment $fundAdjustment): bool
     {
-        return $user->membershipForFamilyId($fundAdjustment->family_id) !== null;
+        return ($user->current_family_id ?? $user->family_id) === $fundAdjustment->family_id
+            && $user->membershipForFamilyId($fundAdjustment->family_id) !== null;
     }
 
     public function create(User $user): bool
@@ -31,7 +32,8 @@ class FundAdjustmentPolicy
 
     public function delete(User $user, FundAdjustment $fundAdjustment): bool
     {
-        return $user->membershipForFamilyId($fundAdjustment->family_id)?->role->canRecordPayments() === true;
+        return ($user->current_family_id ?? $user->family_id) === $fundAdjustment->family_id
+            && $user->membershipForFamilyId($fundAdjustment->family_id)?->role->canRecordPayments() === true;
     }
 
     public function restore(User $user, FundAdjustment $fundAdjustment): bool

--- a/app/Policies/PaymentBatchPolicy.php
+++ b/app/Policies/PaymentBatchPolicy.php
@@ -12,6 +12,10 @@ class PaymentBatchPolicy
 {
     public function view(User $user, PaymentBatch $batch): bool
     {
+        if (($user->current_family_id ?? $user->family_id) !== $batch->family_id) {
+            return false;
+        }
+
         $membership = $user->membershipForFamilyId($batch->family_id);
 
         if ($membership === null) {
@@ -24,7 +28,8 @@ class PaymentBatchPolicy
 
     public function reverse(User $user, PaymentBatch $batch): bool
     {
-        return $user->membershipForFamilyId($batch->family_id)?->role === Role::Admin
+        return ($user->current_family_id ?? $user->family_id) === $batch->family_id
+            && $user->membershipForFamilyId($batch->family_id)?->role === Role::Admin
             && ! $batch->isReversed();
     }
 }

--- a/app/Policies/PaymentBatchPolicy.php
+++ b/app/Policies/PaymentBatchPolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Enums\Role;
 use App\Models\PaymentBatch;
 use App\Models\User;
 
@@ -11,18 +12,19 @@ class PaymentBatchPolicy
 {
     public function view(User $user, PaymentBatch $batch): bool
     {
-        if ($user->membershipForFamilyId($batch->family_id) === null) {
+        $membership = $user->membershipForFamilyId($batch->family_id);
+
+        if ($membership === null) {
             return false;
         }
 
-        return $user->activeRole()->canGenerateReports()
+        return $membership->role->canGenerateReports()
             || $batch->membership?->user_id === $user->id;
     }
 
     public function reverse(User $user, PaymentBatch $batch): bool
     {
-        return $user->isAdmin()
-            && $user->membershipForFamilyId($batch->family_id) !== null
+        return $user->membershipForFamilyId($batch->family_id)?->role === Role::Admin
             && ! $batch->isReversed();
     }
 }

--- a/app/Policies/ReportArtifactPolicy.php
+++ b/app/Policies/ReportArtifactPolicy.php
@@ -12,6 +12,10 @@ class ReportArtifactPolicy
 {
     public function view(User $user, ReportArtifact $artifact): bool
     {
+        if (($user->current_family_id ?? $user->family_id) !== $artifact->family_id) {
+            return false;
+        }
+
         $membership = $user->membershipForFamilyId($artifact->family_id);
 
         if ($membership === null) {

--- a/app/Policies/ReportArtifactPolicy.php
+++ b/app/Policies/ReportArtifactPolicy.php
@@ -12,11 +12,13 @@ class ReportArtifactPolicy
 {
     public function view(User $user, ReportArtifact $artifact): bool
     {
-        if ($user->membershipForFamilyId($artifact->family_id) === null) {
+        $membership = $user->membershipForFamilyId($artifact->family_id);
+
+        if ($membership === null) {
             return false;
         }
 
-        if ($user->activeRole()->canGenerateReports()) {
+        if ($membership->role->canGenerateReports()) {
             return true;
         }
 

--- a/app/Policies/ReportSchedulePolicy.php
+++ b/app/Policies/ReportSchedulePolicy.php
@@ -21,7 +21,6 @@ class ReportSchedulePolicy
 
     public function delete(User $user, ReportSchedule $schedule): bool
     {
-        return $user->activeRole()->canGenerateReports()
-            && $user->membershipForFamilyId($schedule->family_id) !== null;
+        return $user->membershipForFamilyId($schedule->family_id)?->role->canGenerateReports() === true;
     }
 }

--- a/app/Policies/ReportSchedulePolicy.php
+++ b/app/Policies/ReportSchedulePolicy.php
@@ -21,6 +21,7 @@ class ReportSchedulePolicy
 
     public function delete(User $user, ReportSchedule $schedule): bool
     {
-        return $user->membershipForFamilyId($schedule->family_id)?->role->canGenerateReports() === true;
+        return ($user->current_family_id ?? $user->family_id) === $schedule->family_id
+            && $user->membershipForFamilyId($schedule->family_id)?->role->canGenerateReports() === true;
     }
 }

--- a/app/Services/FamilyContributionReviewService.php
+++ b/app/Services/FamilyContributionReviewService.php
@@ -327,8 +327,10 @@ class FamilyContributionReviewService
      */
     private function reversalReport(Family $family, array $filters): array
     {
+        $from = CarbonImmutable::parse($this->filterString($filters, 'date_from'))->startOfDay();
+        $to = CarbonImmutable::parse($this->filterString($filters, 'date_to'))->endOfDay();
         $rows = FinancialReversal::query()->where('family_id', $family->id)
-            ->whereBetween('created_at', [$this->filterString($filters, 'date_from'), $this->filterString($filters, 'date_to')])
+            ->whereBetween('created_at', [$from, $to])
             ->with('reverser:id,name')->latest()->get()->map(fn (FinancialReversal $reversal): array => [
                 'date' => $reversal->created_at->toDateString(),
                 'type' => str($reversal->reversible_type)->headline()->toString(),
@@ -345,8 +347,10 @@ class FamilyContributionReviewService
      */
     private function auditReport(Family $family, array $filters): array
     {
+        $from = CarbonImmutable::parse($this->filterString($filters, 'date_from'))->startOfDay();
+        $to = CarbonImmutable::parse($this->filterString($filters, 'date_to'))->endOfDay();
         $rows = AuditEvent::query()->where('family_id', $family->id)
-            ->whereBetween('created_at', [$this->filterString($filters, 'date_from'), $this->filterString($filters, 'date_to')])
+            ->whereBetween('created_at', [$from, $to])
             ->with('actor:id,name')->latest()->get()->map(fn (AuditEvent $event): array => [
                 'date' => $event->created_at->toDateTimeString(),
                 'action' => $event->action,

--- a/resources/js/pages/Reports/Index.vue
+++ b/resources/js/pages/Reports/Index.vue
@@ -11,6 +11,7 @@ import { exportMethod } from '@/routes/reports';
 import { type BreadcrumbItem } from '@/types';
 import { Head, router, useForm } from '@inertiajs/vue3';
 import { CalendarClock, Download, FileBarChart2, Trash2 } from '@lucide/vue';
+import { watch } from 'vue';
 
 interface Option {
     value: string;
@@ -39,9 +40,16 @@ const props = defineProps<Props>();
 const today = new Date();
 const yearStart = `${today.getFullYear()}-01-01`;
 const yearEnd = `${today.getFullYear()}-12-31`;
-const defaultRun = new Date(today.getTime() + 60 * 60 * 1000)
-    .toISOString()
-    .slice(0, 16);
+
+function toDatetimeLocalValue(date: Date): string {
+    const timezoneOffset = date.getTimezoneOffset() * 60 * 1000;
+
+    return new Date(date.getTime() - timezoneOffset).toISOString().slice(0, 16);
+}
+
+const defaultRun = toDatetimeLocalValue(
+    new Date(today.getTime() + 60 * 60 * 1000),
+);
 const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 const exportFilters = useForm({
@@ -70,6 +78,15 @@ const scheduleForm = useForm({
 });
 
 const breadcrumbs: BreadcrumbItem[] = [{ title: 'Reports', href: index().url }];
+
+watch(
+    () => scheduleForm.report_type,
+    (reportType) => {
+        if (reportType !== 'member_statement') {
+            scheduleForm.filters.member_id = '';
+        }
+    },
+);
 
 function submitSchedule(): void {
     scheduleForm
@@ -245,6 +262,7 @@ function removeSchedule(id: number): void {
                     <label class="grid gap-1 text-xs text-muted-foreground"
                         >Schedule name<input
                             v-model="scheduleForm.name"
+                            name="schedule_name"
                             required
                             class="rounded-md border bg-background px-3 py-2 text-sm text-foreground" /><InputError
                             :message="scheduleForm.errors.name"
@@ -252,6 +270,7 @@ function removeSchedule(id: number): void {
                     <label class="grid gap-1 text-xs text-muted-foreground"
                         >Report type<select
                             v-model="scheduleForm.report_type"
+                            name="schedule_report_type"
                             class="rounded-md border bg-background px-3 py-2 text-sm text-foreground"
                         >
                             <option
@@ -263,6 +282,28 @@ function removeSchedule(id: number): void {
                             </option>
                         </select></label
                     >
+                    <label
+                        v-if="scheduleForm.report_type === 'member_statement'"
+                        class="grid gap-1 text-xs text-muted-foreground"
+                        >Statement member<select
+                            v-model="scheduleForm.filters.member_id"
+                            name="schedule_member_id"
+                            required
+                            class="rounded-md border bg-background px-3 py-2 text-sm text-foreground"
+                        >
+                            <option disabled value="">Select a member</option>
+                            <option
+                                v-for="member in members"
+                                :key="member.id"
+                                :value="member.id"
+                            >
+                                {{ member.name }}
+                            </option>
+                        </select>
+                        <InputError
+                            :message="scheduleForm.errors['filters.member_id']"
+                        />
+                    </label>
                     <label class="grid gap-1 text-xs text-muted-foreground"
                         >Format<select
                             v-model="scheduleForm.format"
@@ -294,13 +335,16 @@ function removeSchedule(id: number): void {
                     <label class="grid gap-1 text-xs text-muted-foreground"
                         >Run first at<input
                             v-model="scheduleForm.next_run_at"
+                            name="schedule_next_run_at"
                             required
                             type="datetime-local"
-                            class="rounded-md border bg-background px-3 py-2 text-sm text-foreground"
+                            class="rounded-md border bg-background px-3 py-2 text-sm text-foreground" /><InputError
+                            :message="scheduleForm.errors.next_run_at"
                     /></label>
                     <label class="grid gap-1 text-xs text-muted-foreground"
                         >Recipients<input
                             v-model="scheduleForm.recipients_text"
+                            name="schedule_recipients"
                             required
                             placeholder="email@example.com, 974..."
                             class="rounded-md border bg-background px-3 py-2 text-sm text-foreground" /><InputError

--- a/tests/Browser/FinancialOperationsFlowTest.php
+++ b/tests/Browser/FinancialOperationsFlowTest.php
@@ -7,6 +7,7 @@ use App\Models\Expense;
 use App\Models\FamilyCategory;
 use App\Models\FamilyInvitation;
 use App\Models\FundAdjustment;
+use App\Models\ReportSchedule;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Mail;
 
@@ -92,6 +93,55 @@ describe('Financial and family administration flows (Browser)', function () {
             ->where('recorded_by', $this->admin->id)
             ->where('description', 'Browser workflow opening balance')
             ->exists())->toBeTrue();
+    });
+
+    it('schedules a member statement with a browser-local first run', function () {
+        $member = createBrowserMember($this->family, [
+            'name' => 'Scheduled Statement Member',
+            'email' => 'scheduled-statement@example.com',
+        ]);
+        $page = loginBrowserAs($this->financialSecretary);
+
+        $page->navigate(route('reports.index'))
+            ->assertSee('Schedule delivery')
+            ->assertDontSee('Statement member');
+
+        $defaultRun = $page->script(<<<'JS'
+            () => {
+                const field = document.querySelector('[name="schedule_next_run_at"]');
+                const target = new Date(Date.now() + 60 * 60 * 1000);
+                const offset = target.getTimezoneOffset() * 60 * 1000;
+                const expected = new Date(target.getTime() - offset).toISOString().slice(0, 16);
+
+                return {
+                    actual: field instanceof HTMLInputElement ? field.value : null,
+                    expected,
+                };
+            }
+        JS);
+
+        if (! is_array($defaultRun)) {
+            throw new RuntimeException('Expected browser script to return the schedule run time.');
+        }
+
+        expect($defaultRun['actual'] ?? null)->toBe($defaultRun['expected'] ?? null);
+
+        $page->select('schedule_report_type', 'member_statement')
+            ->wait(0.5)
+            ->select('schedule_member_id', (string) $member->id)
+            ->fill('schedule_name', 'Browser member statement')
+            ->fill('schedule_recipients', 'member@example.com')
+            ->click('Create schedule')
+            ->assertSee('Browser member statement')
+            ->assertNoJavaScriptErrors();
+
+        $schedule = ReportSchedule::query()
+            ->where('family_id', $this->family->id)
+            ->where('name', 'Browser member statement')
+            ->firstOrFail();
+
+        expect($schedule->filters['member_id'])->toBe($member->id)
+            ->and($schedule->timezone)->not->toBeEmpty();
     });
 
     it('sends a family invitation through the UI', function () {

--- a/tests/Browser/FinancialOperationsFlowTest.php
+++ b/tests/Browser/FinancialOperationsFlowTest.php
@@ -110,12 +110,13 @@ describe('Financial and family administration flows (Browser)', function () {
             () => {
                 const field = document.querySelector('[name="schedule_next_run_at"]');
                 const target = new Date(Date.now() + 60 * 60 * 1000);
-                const offset = target.getTimezoneOffset() * 60 * 1000;
-                const expected = new Date(target.getTime() - offset).toISOString().slice(0, 16);
+                const actual = field instanceof HTMLInputElement ? field.value : null;
 
                 return {
-                    actual: field instanceof HTMLInputElement ? field.value : null,
-                    expected,
+                    actual,
+                    differenceMs: actual === null
+                        ? null
+                        : Math.abs(new Date(actual).getTime() - target.getTime()),
                 };
             }
         JS);
@@ -124,7 +125,8 @@ describe('Financial and family administration flows (Browser)', function () {
             throw new RuntimeException('Expected browser script to return the schedule run time.');
         }
 
-        expect($defaultRun['actual'] ?? null)->toBe($defaultRun['expected'] ?? null);
+        expect($defaultRun['actual'] ?? null)->toBeString()
+            ->and($defaultRun['differenceMs'] ?? null)->toBeInt()->toBeLessThanOrEqual(120_000);
 
         $page->select('schedule_report_type', 'member_statement')
             ->wait(0.5)

--- a/tests/Feature/PaystackWebhookTest.php
+++ b/tests/Feature/PaystackWebhookTest.php
@@ -57,6 +57,24 @@ it('executes queued Paystack webhooks with a bounded retry schedule', function (
     expect($job->backoff())->toBe([10, 30, 120, 300]);
 });
 
+it('uniquely identifies failed subscription webhooks by nested subscription code', function () {
+    $first = new ProcessPaystackWebhook([
+        'event' => 'invoice.payment_failed',
+        'data' => ['subscription' => ['subscription_code' => 'SUB_first']],
+    ]);
+    $same = new ProcessPaystackWebhook([
+        'event' => 'invoice.payment_failed',
+        'data' => ['subscription' => ['subscription_code' => 'SUB_first']],
+    ]);
+    $second = new ProcessPaystackWebhook([
+        'event' => 'invoice.payment_failed',
+        'data' => ['subscription' => ['subscription_code' => 'SUB_second']],
+    ]);
+
+    expect($first->uniqueId())->toBe($same->uniqueId())
+        ->and($first->uniqueId())->not->toBe($second->uniqueId());
+});
+
 it('does not audit Paystack updates that leave ledger state unchanged', function () {
     $family = Family::factory()->create();
     $member = User::factory()->create(['family_id' => $family->id]);

--- a/tests/Feature/PhaseThreeReportingTest.php
+++ b/tests/Feature/PhaseThreeReportingTest.php
@@ -266,11 +266,14 @@ it('uses the artifact family role when a user belongs to multiple families', fun
     $currentOfficer->ensureFamilyMembership($artifactFamily, Role::Member);
     $artifactFamilyOfficer = User::factory()->member()->create(['family_id' => $currentFamily->id]);
     $artifactFamilyOfficer->ensureFamilyMembership($artifactFamily, Role::FinancialSecretary);
+    $userWithoutMembership = User::factory()->member()->create(['family_id' => $currentFamily->id]);
+    $userWithoutMembership->forceFill(['current_family_id' => $artifactFamily->id])->save();
     $artifact = ReportArtifact::factory()->create(['family_id' => $artifactFamily->id]);
     $policy = app(ReportArtifactPolicy::class);
 
     expect($policy->view($currentOfficer, $artifact))->toBeFalse()
-        ->and($policy->view($artifactFamilyOfficer, $artifact))->toBeTrue();
+        ->and($policy->view($userWithoutMembership, $artifact))->toBeFalse()
+        ->and($policy->view($artifactFamilyOfficer, $artifact))->toBeFalse();
 
     $this->actingAs($currentOfficer)
         ->get(route('reports.artifacts.show', [
@@ -278,6 +281,10 @@ it('uses the artifact family role when a user belongs to multiple families', fun
             'reportArtifact' => $artifact,
         ]))
         ->assertForbidden();
+
+    $artifactFamilyOfficer->switchFamily($artifactFamily);
+
+    expect($policy->view($artifactFamilyOfficer, $artifact))->toBeTrue();
 });
 
 it('includes reversal and audit events throughout the report end date', function () {

--- a/tests/Feature/PhaseThreeReportingTest.php
+++ b/tests/Feature/PhaseThreeReportingTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 use App\Enums\ReportFormat;
 use App\Enums\ReportType;
+use App\Enums\Role;
+use App\Models\AuditEvent;
 use App\Models\Contribution;
 use App\Models\Expense;
 use App\Models\Family;
 use App\Models\FamilyCategory;
+use App\Models\FinancialReversal;
 use App\Models\FundAdjustment;
 use App\Models\Payment;
 use App\Models\PaymentBatch;
@@ -254,6 +257,51 @@ it('enforces artifact policy boundaries and exposes report relationships', funct
         ->and($register->requester?->is($admin))->toBeTrue()
         ->and($register->deliveries->first()?->is($delivery))->toBeTrue()
         ->and($delivery->schedule->is($schedule))->toBeTrue();
+});
+
+it('uses the artifact family role when a user belongs to multiple families', function () {
+    $currentFamily = Family::factory()->create();
+    $artifactFamily = Family::factory()->create();
+    $currentOfficer = User::factory()->financialSecretary()->create(['family_id' => $currentFamily->id]);
+    $currentOfficer->ensureFamilyMembership($artifactFamily, Role::Member);
+    $artifactFamilyOfficer = User::factory()->member()->create(['family_id' => $currentFamily->id]);
+    $artifactFamilyOfficer->ensureFamilyMembership($artifactFamily, Role::FinancialSecretary);
+    $artifact = ReportArtifact::factory()->create(['family_id' => $artifactFamily->id]);
+    $policy = app(ReportArtifactPolicy::class);
+
+    expect($policy->view($currentOfficer, $artifact))->toBeFalse()
+        ->and($policy->view($artifactFamilyOfficer, $artifact))->toBeTrue();
+
+    $this->actingAs($currentOfficer)
+        ->get(route('reports.artifacts.show', [
+            'current_family' => $currentFamily->slug,
+            'reportArtifact' => $artifact,
+        ]))
+        ->assertForbidden();
+});
+
+it('includes reversal and audit events throughout the report end date', function () {
+    [$family, $admin] = phaseThreeReportingFixture();
+    $expense = Expense::factory()->recordedBy($admin)->create(['family_id' => $family->id]);
+    FinancialReversal::factory()->create([
+        'family_id' => $family->id,
+        'reversible_type' => Expense::MORPH_TYPE,
+        'reversible_id' => $expense->id,
+        'reversed_by' => $admin->id,
+        'created_at' => '2026-06-30 18:30:00',
+    ]);
+    AuditEvent::factory()->create([
+        'family_id' => $family->id,
+        'actor_id' => $admin->id,
+        'auditable_type' => Expense::MORPH_TYPE,
+        'auditable_id' => $expense->id,
+        'created_at' => '2026-06-30 23:59:59',
+    ]);
+    $filters = ['date_from' => '2026-06-30', 'date_to' => '2026-06-30'];
+    $service = app(FamilyContributionReviewService::class);
+
+    expect($service->report($family, ReportType::Reversals, $filters)['rows'])->toHaveCount(1)
+        ->and($service->report($family, ReportType::AuditActivity, $filters)['rows'])->toHaveCount(1);
 });
 
 it('sanitizes null boolean structured and formula csv cells', function () {

--- a/tests/Feature/PhaseThreeScheduledReportsTest.php
+++ b/tests/Feature/PhaseThreeScheduledReportsTest.php
@@ -6,6 +6,7 @@ use App\Enums\ReportDeliveryStatus;
 use App\Enums\ReportFormat;
 use App\Enums\ReportScheduleFrequency;
 use App\Enums\ReportType;
+use App\Enums\Role;
 use App\Jobs\GenerateScheduledReport;
 use App\Mail\ScheduledReportMail;
 use App\Models\Contribution;
@@ -18,6 +19,7 @@ use App\Policies\ReportSchedulePolicy;
 use App\Services\ReportArtifactService;
 use App\Services\WhatsAppService;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 
@@ -49,7 +51,7 @@ it('creates validated schedules and dispatches one unique job per due period', f
         'recipients' => ['treasurer@example.test'],
         'frequency' => ReportScheduleFrequency::Monthly->value,
         'timezone' => 'Asia/Qatar',
-        'next_run_at' => now()->addMinute()->toDateTimeString(),
+        'next_run_at' => now('Asia/Qatar')->addMinute()->toDateTimeString(),
     ])->assertRedirect();
 
     $schedule = ReportSchedule::query()->firstOrFail();
@@ -116,7 +118,7 @@ it('validates channels recipients and schedule ownership', function () {
         'frequency' => 'hourly',
         'timezone' => 'not-a-timezone',
         'next_run_at' => now()->subDay(),
-    ])->assertSessionHasErrors(['name', 'report_type', 'format', 'filters.date_from', 'channels', 'recipients', 'frequency', 'timezone', 'next_run_at']);
+    ])->assertSessionHasErrors(['name', 'report_type', 'format', 'filters.date_from', 'channels', 'recipients', 'frequency', 'timezone']);
 
     $this->actingAs($member)->post(route('reports.schedules.store', ['current_family' => $family->slug]), [])->assertForbidden();
 
@@ -133,6 +135,65 @@ it('validates channels recipients and schedule ownership', function () {
         ->delete(route('reports.schedules.destroy', ['current_family' => $family->slug, 'reportSchedule' => $schedule]))
         ->assertRedirect();
     expect(ReportSchedule::query()->find($schedule->id))->toBeNull();
+});
+
+it('requires a same-family member for scheduled member statements', function () {
+    Date::setTestNow('2026-07-31 00:00:00 UTC');
+    [$family, $admin] = phaseThreeScheduleFixture();
+    $member = User::factory()->member()->create(['family_id' => $family->id]);
+    $foreignMember = User::factory()->member()->create();
+    $payload = [
+        'name' => 'Member statement',
+        'report_type' => ReportType::MemberStatement->value,
+        'format' => ReportFormat::Pdf->value,
+        'filters' => ['date_from' => '2026-06-01', 'date_to' => '2026-06-30'],
+        'channels' => ['email'],
+        'recipients' => ['member@example.test'],
+        'frequency' => ReportScheduleFrequency::Monthly->value,
+        'timezone' => 'Asia/Qatar',
+        'next_run_at' => '2026-08-01T09:00',
+    ];
+    $route = route('reports.schedules.store', ['current_family' => $family->slug]);
+
+    $this->actingAs($admin)->post($route, [...$payload, 'next_run_at' => '2026-07-30T09:00'])
+        ->assertSessionHasErrors(['next_run_at']);
+    $this->actingAs($admin)->post($route, $payload)
+        ->assertSessionHasErrors(['filters.member_id']);
+    $this->post($route, [...$payload, 'filters' => [...$payload['filters'], 'member_id' => $foreignMember->id]])
+        ->assertSessionHasErrors(['filters.member_id']);
+    $this->post($route, [...$payload, 'filters' => [...$payload['filters'], 'member_id' => $member->id]])
+        ->assertSessionHasNoErrors()
+        ->assertRedirect();
+
+    $schedule = ReportSchedule::query()->firstOrFail();
+    expect($schedule->filters['member_id'])->toBe($member->id)
+        ->and($schedule->timezone)->toBe('Asia/Qatar')
+        ->and($schedule->next_run_at->utc()->format('Y-m-d H:i:s'))->toBe('2026-08-01 06:00:00');
+
+    Date::setTestNow();
+});
+
+it('uses the schedule family role when deleting across memberships', function () {
+    $currentFamily = Family::factory()->create();
+    $scheduleFamily = Family::factory()->create();
+    $currentOfficer = User::factory()->financialSecretary()->create(['family_id' => $currentFamily->id]);
+    $currentOfficer->ensureFamilyMembership($scheduleFamily, Role::Member);
+    $scheduleFamilyOfficer = User::factory()->member()->create(['family_id' => $currentFamily->id]);
+    $scheduleFamilyOfficer->ensureFamilyMembership($scheduleFamily, Role::FinancialSecretary);
+    $schedule = ReportSchedule::factory()->create(['family_id' => $scheduleFamily->id]);
+    $policy = app(ReportSchedulePolicy::class);
+
+    expect($policy->delete($currentOfficer, $schedule))->toBeFalse()
+        ->and($policy->delete($scheduleFamilyOfficer, $schedule))->toBeTrue();
+
+    $this->actingAs($currentOfficer)
+        ->delete(route('reports.schedules.destroy', [
+            'current_family' => $currentFamily->slug,
+            'reportSchedule' => $schedule,
+        ]))
+        ->assertForbidden();
+
+    expect($schedule->fresh())->not->toBeNull();
 });
 
 it('skips unavailable and completed jobs and records whatsapp success and failure', function () {

--- a/tests/Feature/PhaseThreeScheduledReportsTest.php
+++ b/tests/Feature/PhaseThreeScheduledReportsTest.php
@@ -184,7 +184,7 @@ it('uses the schedule family role when deleting across memberships', function ()
     $policy = app(ReportSchedulePolicy::class);
 
     expect($policy->delete($currentOfficer, $schedule))->toBeFalse()
-        ->and($policy->delete($scheduleFamilyOfficer, $schedule))->toBeTrue();
+        ->and($policy->delete($scheduleFamilyOfficer, $schedule))->toBeFalse();
 
     $this->actingAs($currentOfficer)
         ->delete(route('reports.schedules.destroy', [
@@ -194,6 +194,10 @@ it('uses the schedule family role when deleting across memberships', function ()
         ->assertForbidden();
 
     expect($schedule->fresh())->not->toBeNull();
+
+    $scheduleFamilyOfficer->switchFamily($scheduleFamily);
+
+    expect($policy->delete($scheduleFamilyOfficer, $schedule))->toBeTrue();
 });
 
 it('skips unavailable and completed jobs and records whatsapp success and failure', function () {

--- a/tests/Feature/PhaseTwoLedgerTest.php
+++ b/tests/Feature/PhaseTwoLedgerTest.php
@@ -10,6 +10,7 @@ use App\Actions\ReverseFundAdjustment;
 use App\Actions\ReversePaymentBatch;
 use App\Enums\PaymentMethod;
 use App\Enums\PaymentSource;
+use App\Enums\Role;
 use App\Models\AuditEvent;
 use App\Models\Contribution;
 use App\Models\Expense;
@@ -328,4 +329,34 @@ it('exposes ledger model relationships, scopes, labels, and policy boundaries', 
     $orphanPayment = new Payment;
 
     expect(app(PaymentPolicy::class)->view($admin, $orphanPayment))->toBeFalse();
+});
+
+it('uses the receipt family role for viewing and reversing multi-family batches', function () {
+    $currentFamily = Family::factory()->create();
+    $batchFamily = Family::factory()->create();
+    $currentAdmin = User::factory()->admin()->create(['family_id' => $currentFamily->id]);
+    $currentAdmin->ensureFamilyMembership($batchFamily, Role::Member);
+    $batchFamilyMember = User::factory()->member()->create(['family_id' => $batchFamily->id]);
+    $batch = PaymentBatch::factory()->create([
+        'family_id' => $batchFamily->id,
+        'family_membership_id' => $batchFamilyMember->membershipForFamily($batchFamily)?->id,
+        'recorded_by' => $batchFamilyMember->id,
+    ]);
+    $batchFamilyAdmin = User::factory()->member()->create(['family_id' => $currentFamily->id]);
+    $batchFamilyAdmin->ensureFamilyMembership($batchFamily, Role::Admin);
+    $policy = app(PaymentBatchPolicy::class);
+
+    expect($policy->view($currentAdmin, $batch))->toBeFalse()
+        ->and($policy->reverse($currentAdmin, $batch))->toBeFalse()
+        ->and($policy->view($batchFamilyAdmin, $batch))->toBeTrue()
+        ->and($policy->reverse($batchFamilyAdmin, $batch))->toBeTrue();
+
+    $this->actingAs($currentAdmin)
+        ->post(route('payment-batches.reverse', [
+            'current_family' => $currentFamily->slug,
+            'payment_batch' => $batch,
+        ]), ['reason' => 'Must not cross families'])
+        ->assertForbidden();
+
+    expect($batch->reversal()->exists())->toBeFalse();
 });

--- a/tests/Feature/PhaseTwoLedgerTest.php
+++ b/tests/Feature/PhaseTwoLedgerTest.php
@@ -344,12 +344,15 @@ it('uses the receipt family role for viewing and reversing multi-family batches'
     ]);
     $batchFamilyAdmin = User::factory()->member()->create(['family_id' => $currentFamily->id]);
     $batchFamilyAdmin->ensureFamilyMembership($batchFamily, Role::Admin);
+    $userWithoutMembership = User::factory()->member()->create(['family_id' => $currentFamily->id]);
+    $userWithoutMembership->forceFill(['current_family_id' => $batchFamily->id])->save();
     $policy = app(PaymentBatchPolicy::class);
 
     expect($policy->view($currentAdmin, $batch))->toBeFalse()
+        ->and($policy->view($userWithoutMembership, $batch))->toBeFalse()
         ->and($policy->reverse($currentAdmin, $batch))->toBeFalse()
-        ->and($policy->view($batchFamilyAdmin, $batch))->toBeTrue()
-        ->and($policy->reverse($batchFamilyAdmin, $batch))->toBeTrue();
+        ->and($policy->view($batchFamilyAdmin, $batch))->toBeFalse()
+        ->and($policy->reverse($batchFamilyAdmin, $batch))->toBeFalse();
 
     $this->actingAs($currentAdmin)
         ->post(route('payment-batches.reverse', [
@@ -359,4 +362,9 @@ it('uses the receipt family role for viewing and reversing multi-family batches'
         ->assertForbidden();
 
     expect($batch->reversal()->exists())->toBeFalse();
+
+    $batchFamilyAdmin->switchFamily($batchFamily);
+
+    expect($policy->view($batchFamilyAdmin, $batch))->toBeTrue()
+        ->and($policy->reverse($batchFamilyAdmin, $batch))->toBeTrue();
 });

--- a/tests/Feature/Policies/ExpensePolicyTest.php
+++ b/tests/Feature/Policies/ExpensePolicyTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\Role;
 use App\Models\Expense;
 use App\Models\Family;
 use App\Models\User;
@@ -38,6 +39,27 @@ it('allows only same-family admins to reverse expenses', function () {
         ->and($this->policy->delete($this->financialSecretary, $this->expense))->toBeFalse()
         ->and($this->policy->delete($this->member, $this->expense))->toBeFalse()
         ->and($this->policy->delete($this->outsider, $this->expense))->toBeFalse();
+});
+
+it('uses the expense family role when a user belongs to multiple families', function () {
+    $this->admin->ensureFamilyMembership($this->otherFamily, Role::Member);
+    $otherExpense = Expense::factory()->recordedBy($this->outsider)->create([
+        'family_id' => $this->otherFamily->id,
+    ]);
+    $otherFamilyAdmin = User::factory()->member()->create(['family_id' => $this->family->id]);
+    $otherFamilyAdmin->ensureFamilyMembership($this->otherFamily, Role::Admin);
+
+    expect($this->policy->delete($this->admin, $otherExpense))->toBeFalse()
+        ->and($this->policy->delete($otherFamilyAdmin, $otherExpense))->toBeTrue();
+
+    $this->actingAs($this->admin)
+        ->post(route('expenses.reverse', [
+            'current_family' => $this->family->slug,
+            'expense' => $otherExpense,
+        ]), ['reason' => 'Must not cross families'])
+        ->assertForbidden();
+
+    expect($otherExpense->reversal()->exists())->toBeFalse();
 });
 
 it('denies direct mutation of immutable expenses', function (string $ability) {

--- a/tests/Feature/Policies/ExpensePolicyTest.php
+++ b/tests/Feature/Policies/ExpensePolicyTest.php
@@ -50,7 +50,7 @@ it('uses the expense family role when a user belongs to multiple families', func
     $otherFamilyAdmin->ensureFamilyMembership($this->otherFamily, Role::Admin);
 
     expect($this->policy->delete($this->admin, $otherExpense))->toBeFalse()
-        ->and($this->policy->delete($otherFamilyAdmin, $otherExpense))->toBeTrue();
+        ->and($this->policy->delete($otherFamilyAdmin, $otherExpense))->toBeFalse();
 
     $this->actingAs($this->admin)
         ->post(route('expenses.reverse', [
@@ -60,6 +60,10 @@ it('uses the expense family role when a user belongs to multiple families', func
         ->assertForbidden();
 
     expect($otherExpense->reversal()->exists())->toBeFalse();
+
+    $otherFamilyAdmin->switchFamily($this->otherFamily);
+
+    expect($this->policy->delete($otherFamilyAdmin, $otherExpense))->toBeTrue();
 });
 
 it('denies direct mutation of immutable expenses', function (string $ability) {

--- a/tests/Feature/Policies/FundAdjustmentPolicyTest.php
+++ b/tests/Feature/Policies/FundAdjustmentPolicyTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\Role;
 use App\Models\Family;
 use App\Models\FundAdjustment;
 use App\Models\User;
@@ -38,6 +39,27 @@ it('allows only same-family payment recorders to reverse fund adjustments', func
         ->and($this->policy->delete($this->financialSecretary, $this->fundAdjustment))->toBeTrue()
         ->and($this->policy->delete($this->member, $this->fundAdjustment))->toBeFalse()
         ->and($this->policy->delete($this->outsider, $this->fundAdjustment))->toBeFalse();
+});
+
+it('uses the adjustment family role when a user belongs to multiple families', function () {
+    $this->admin->ensureFamilyMembership($this->otherFamily, Role::Member);
+    $otherAdjustment = FundAdjustment::factory()->recordedBy($this->outsider)->create([
+        'family_id' => $this->otherFamily->id,
+    ]);
+    $otherFamilyOfficer = User::factory()->member()->create(['family_id' => $this->family->id]);
+    $otherFamilyOfficer->ensureFamilyMembership($this->otherFamily, Role::FinancialSecretary);
+
+    expect($this->policy->delete($this->admin, $otherAdjustment))->toBeFalse()
+        ->and($this->policy->delete($otherFamilyOfficer, $otherAdjustment))->toBeTrue();
+
+    $this->actingAs($this->admin)
+        ->post(route('fund-adjustments.reverse', [
+            'current_family' => $this->family->slug,
+            'fund_adjustment' => $otherAdjustment,
+        ]), ['reason' => 'Must not cross families'])
+        ->assertForbidden();
+
+    expect($otherAdjustment->reversal()->exists())->toBeFalse();
 });
 
 it('denies direct mutation of immutable fund adjustments', function (string $ability) {

--- a/tests/Feature/Policies/FundAdjustmentPolicyTest.php
+++ b/tests/Feature/Policies/FundAdjustmentPolicyTest.php
@@ -50,7 +50,7 @@ it('uses the adjustment family role when a user belongs to multiple families', f
     $otherFamilyOfficer->ensureFamilyMembership($this->otherFamily, Role::FinancialSecretary);
 
     expect($this->policy->delete($this->admin, $otherAdjustment))->toBeFalse()
-        ->and($this->policy->delete($otherFamilyOfficer, $otherAdjustment))->toBeTrue();
+        ->and($this->policy->delete($otherFamilyOfficer, $otherAdjustment))->toBeFalse();
 
     $this->actingAs($this->admin)
         ->post(route('fund-adjustments.reverse', [
@@ -60,6 +60,10 @@ it('uses the adjustment family role when a user belongs to multiple families', f
         ->assertForbidden();
 
     expect($otherAdjustment->reversal()->exists())->toBeFalse();
+
+    $otherFamilyOfficer->switchFamily($this->otherFamily);
+
+    expect($this->policy->delete($otherFamilyOfficer, $otherAdjustment))->toBeTrue();
 });
 
 it('denies direct mutation of immutable fund adjustments', function (string $ability) {


### PR DESCRIPTION
## Summary
- derive authorization from each resource's owning-family membership, including receipt viewing
- require and scope scheduled member-statement recipients, normalize schedule times from the selected timezone to UTC, and fix inclusive report end dates
- include nested Paystack subscription codes in webhook uniqueness keys
- add multi-family policy and endpoint regressions for all affected flows

## Verification
- composer ci:check
- 1,221 tests, 5,862 assertions
- 100.0% coverage