### PR TITLE
Enable automatic staging deployments

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -78,6 +78,9 @@ jobs:
               exit 1
             fi
             git fetch origin staging
-            git merge-base --is-ancestor '${{ github.sha }}' origin/staging
+            if [ "$(git rev-parse origin/staging)" != '${{ github.sha }}' ]; then
+              echo "Refusing to deploy a commit that is not the current origin/staging tip."
+              exit 1
+            fi
             git checkout -B staging '${{ github.sha }}'
             STAGING_COMMIT='${{ github.sha }}' /var/www/contribution-tracker-staging/deployment/deploy-staging.sh

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Validate Staging Ref
+        run: test "$GITHUB_REF" = "refs/heads/staging"
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -67,7 +70,14 @@ jobs:
           username: deployer
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
+            set -euo pipefail
             cd /var/www/contribution-tracker-staging
+            if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+              echo "Staging checkout has local tracked changes. Refusing to deploy over them."
+              git status --short
+              exit 1
+            fi
             git fetch origin staging
-            git checkout -B staging origin/staging
-            /var/www/contribution-tracker-staging/deployment/deploy-staging.sh
+            git merge-base --is-ancestor '${{ github.sha }}' origin/staging
+            git checkout -B staging '${{ github.sha }}'
+            STAGING_COMMIT='${{ github.sha }}' /var/www/contribution-tracker-staging/deployment/deploy-staging.sh

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,11 +1,14 @@
 name: Deploy to Staging
 
 on:
+  push:
+    branches:
+      - staging
   workflow_dispatch:
 
 concurrency:
   group: staging-deploy
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   test:

--- a/deployment/deploy-staging.sh
+++ b/deployment/deploy-staging.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 APP_DIR="${APP_DIR:-/var/www/contribution-tracker-staging}"
 STAGING_BRANCH="${STAGING_BRANCH:-staging}"
+STAGING_COMMIT="${STAGING_COMMIT:-}"
+
+if [[ ! "$STAGING_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "STAGING_COMMIT must be the full commit SHA validated by the staging workflow."
+    exit 1
+fi
 
 cd "$APP_DIR"
 
@@ -15,7 +21,19 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 fi
 
 git fetch origin "$STAGING_BRANCH"
-git merge --ff-only "origin/$STAGING_BRANCH"
+if ! git merge-base --is-ancestor "$STAGING_COMMIT" "origin/$STAGING_BRANCH"; then
+    echo "Refusing to deploy a commit that is not contained in origin/$STAGING_BRANCH."
+    exit 1
+fi
+
+git cat-file -e "${STAGING_COMMIT}^{commit}"
+git checkout -B "$STAGING_BRANCH" "$STAGING_COMMIT"
+
+if [ "$(git rev-parse HEAD)" != "$STAGING_COMMIT" ]; then
+    echo "Staging checkout did not resolve to the requested commit."
+    exit 1
+fi
+
 echo "Deploying $(git rev-parse --short HEAD) to staging"
 
 composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader

--- a/deployment/deploy-staging.sh
+++ b/deployment/deploy-staging.sh
@@ -21,8 +21,9 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 fi
 
 git fetch origin "$STAGING_BRANCH"
-if ! git merge-base --is-ancestor "$STAGING_COMMIT" "origin/$STAGING_BRANCH"; then
-    echo "Refusing to deploy a commit that is not contained in origin/$STAGING_BRANCH."
+REMOTE_STAGING_COMMIT="$(git rev-parse "origin/$STAGING_BRANCH")"
+if [ "$REMOTE_STAGING_COMMIT" != "$STAGING_COMMIT" ]; then
+    echo "Refusing to deploy a commit that is not the current origin/$STAGING_BRANCH tip."
     exit 1
 fi
 

--- a/tests/Unit/DeploymentWorkflowTest.php
+++ b/tests/Unit/DeploymentWorkflowTest.php
@@ -29,7 +29,97 @@ it('deploys staging automatically and supports manual dispatch', function () {
         throw new RuntimeException('Expected the staging deployment workflow to define concurrency controls.');
     }
 
+    $jobs = $workflow['jobs'] ?? null;
+
+    if (! is_array($jobs)) {
+        throw new RuntimeException('Expected the staging deployment workflow to define jobs.');
+    }
+
+    $testJob = $jobs['test'] ?? null;
+
+    if (! is_array($testJob)) {
+        throw new RuntimeException('Expected the staging deployment workflow to define a test job.');
+    }
+
+    $testSteps = $testJob['steps'] ?? null;
+
+    if (! is_array($testSteps)) {
+        throw new RuntimeException('Expected the staging deployment workflow to define test steps.');
+    }
+
+    $stagingRefValidationStep = $testSteps[0] ?? null;
+
+    if (! is_array($stagingRefValidationStep)) {
+        throw new RuntimeException('Expected the staging deployment workflow to validate its branch ref.');
+    }
+
+    $deployJob = $jobs['deploy'] ?? null;
+
+    if (! is_array($deployJob)) {
+        throw new RuntimeException('Expected the staging deployment workflow to define a deploy job.');
+    }
+
+    $deploySteps = $deployJob['steps'] ?? null;
+
+    if (! is_array($deploySteps)) {
+        throw new RuntimeException('Expected the staging deployment workflow to define deploy steps.');
+    }
+
+    $deployStep = $deploySteps[0] ?? null;
+
+    if (! is_array($deployStep)) {
+        throw new RuntimeException('Expected the staging deployment workflow to define its server deploy step.');
+    }
+
+    $deployStepConfiguration = $deployStep['with'] ?? null;
+
+    if (! is_array($deployStepConfiguration)) {
+        throw new RuntimeException('Expected the staging server deploy step to define configuration.');
+    }
+
+    $remoteScript = $deployStepConfiguration['script'] ?? null;
+
     expect($pushTrigger['branches'] ?? null)->toBe(['staging'])
         ->and(array_key_exists('workflow_dispatch', $triggers))->toBeTrue()
-        ->and($concurrency['cancel-in-progress'] ?? null)->toBeFalse();
+        ->and($concurrency['cancel-in-progress'] ?? null)->toBeFalse()
+        ->and($stagingRefValidationStep['run'] ?? null)->toBe('test "$GITHUB_REF" = "refs/heads/staging"')
+        ->and($remoteScript)->toBeString()
+        ->toStartWith("set -euo pipefail\n")
+        ->toContain('git checkout -B staging \'${{ github.sha }}\'')
+        ->toContain('${{ github.sha }}')
+        ->not->toContain('git checkout -B staging origin/staging');
+});
+
+it('checks out the exact staging commit validated by the workflow', function () {
+    $deploymentScript = file_get_contents(__DIR__.'/../../deployment/deploy-staging.sh');
+
+    if ($deploymentScript === false) {
+        throw new RuntimeException('Unable to read the staging deployment script.');
+    }
+
+    expect($deploymentScript)
+        ->toContain('STAGING_COMMIT="${STAGING_COMMIT:-}"')
+        ->toContain('git merge-base --is-ancestor "$STAGING_COMMIT" "origin/$STAGING_BRANCH"')
+        ->toContain('git cat-file -e "${STAGING_COMMIT}^{commit}"')
+        ->toContain('git checkout -B "$STAGING_BRANCH" "$STAGING_COMMIT"')
+        ->toContain('if [ "$(git rev-parse HEAD)" != "$STAGING_COMMIT" ]; then')
+        ->not->toContain('git merge --ff-only');
+
+    $fetchPosition = strpos($deploymentScript, 'git fetch origin "$STAGING_BRANCH"');
+    $ancestorCheckPosition = strpos($deploymentScript, 'git merge-base --is-ancestor');
+    $checkoutPosition = strpos($deploymentScript, 'git checkout -B');
+    $installPosition = strpos($deploymentScript, 'composer install');
+
+    if (
+        $fetchPosition === false
+        || $ancestorCheckPosition === false
+        || $checkoutPosition === false
+        || $installPosition === false
+    ) {
+        throw new RuntimeException('Expected the staging deployment script to contain its guarded checkout sequence.');
+    }
+
+    expect($fetchPosition)->toBeLessThan($ancestorCheckPosition)
+        ->and($ancestorCheckPosition)->toBeLessThan($checkoutPosition)
+        ->and($checkoutPosition)->toBeLessThan($installPosition);
 });

--- a/tests/Unit/DeploymentWorkflowTest.php
+++ b/tests/Unit/DeploymentWorkflowTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Yaml\Yaml;
+
+it('deploys staging automatically and supports manual dispatch', function () {
+    $workflow = Yaml::parseFile(__DIR__.'/../../.github/workflows/deploy-staging.yml');
+
+    if (! is_array($workflow)) {
+        throw new RuntimeException('Expected the staging deployment workflow to be valid YAML.');
+    }
+
+    $triggers = $workflow['on'] ?? null;
+
+    if (! is_array($triggers)) {
+        throw new RuntimeException('Expected the staging deployment workflow to define triggers.');
+    }
+
+    $pushTrigger = $triggers['push'] ?? null;
+
+    if (! is_array($pushTrigger)) {
+        throw new RuntimeException('Expected the staging deployment workflow to define a push trigger.');
+    }
+
+    $concurrency = $workflow['concurrency'] ?? null;
+
+    if (! is_array($concurrency)) {
+        throw new RuntimeException('Expected the staging deployment workflow to define concurrency controls.');
+    }
+
+    expect($pushTrigger['branches'] ?? null)->toBe(['staging'])
+        ->and(array_key_exists('workflow_dispatch', $triggers))->toBeTrue()
+        ->and($concurrency['cancel-in-progress'] ?? null)->toBeFalse();
+});

--- a/tests/Unit/DeploymentWorkflowTest.php
+++ b/tests/Unit/DeploymentWorkflowTest.php
@@ -85,6 +85,7 @@ it('deploys staging automatically and supports manual dispatch', function () {
         ->and($stagingRefValidationStep['run'] ?? null)->toBe('test "$GITHUB_REF" = "refs/heads/staging"')
         ->and($remoteScript)->toBeString()
         ->toStartWith("set -euo pipefail\n")
+        ->toContain('if [ "$(git rev-parse origin/staging)" != \'${{ github.sha }}\' ]; then')
         ->toContain('git checkout -B staging \'${{ github.sha }}\'')
         ->toContain('${{ github.sha }}')
         ->not->toContain('git checkout -B staging origin/staging');
@@ -99,27 +100,29 @@ it('checks out the exact staging commit validated by the workflow', function () 
 
     expect($deploymentScript)
         ->toContain('STAGING_COMMIT="${STAGING_COMMIT:-}"')
-        ->toContain('git merge-base --is-ancestor "$STAGING_COMMIT" "origin/$STAGING_BRANCH"')
+        ->toContain('REMOTE_STAGING_COMMIT="$(git rev-parse "origin/$STAGING_BRANCH")"')
+        ->toContain('if [ "$REMOTE_STAGING_COMMIT" != "$STAGING_COMMIT" ]; then')
         ->toContain('git cat-file -e "${STAGING_COMMIT}^{commit}"')
         ->toContain('git checkout -B "$STAGING_BRANCH" "$STAGING_COMMIT"')
         ->toContain('if [ "$(git rev-parse HEAD)" != "$STAGING_COMMIT" ]; then')
-        ->not->toContain('git merge --ff-only');
+        ->not->toContain('git merge --ff-only')
+        ->not->toContain('git merge-base --is-ancestor');
 
     $fetchPosition = strpos($deploymentScript, 'git fetch origin "$STAGING_BRANCH"');
-    $ancestorCheckPosition = strpos($deploymentScript, 'git merge-base --is-ancestor');
+    $tipCheckPosition = strpos($deploymentScript, 'if [ "$REMOTE_STAGING_COMMIT" != "$STAGING_COMMIT" ]; then');
     $checkoutPosition = strpos($deploymentScript, 'git checkout -B');
     $installPosition = strpos($deploymentScript, 'composer install');
 
     if (
         $fetchPosition === false
-        || $ancestorCheckPosition === false
+        || $tipCheckPosition === false
         || $checkoutPosition === false
         || $installPosition === false
     ) {
         throw new RuntimeException('Expected the staging deployment script to contain its guarded checkout sequence.');
     }
 
-    expect($fetchPosition)->toBeLessThan($ancestorCheckPosition)
-        ->and($ancestorCheckPosition)->toBeLessThan($checkoutPosition)
+    expect($fetchPosition)->toBeLessThan($tipCheckPosition)
+        ->and($tipCheckPosition)->toBeLessThan($checkoutPosition)
         ->and($checkoutPosition)->toBeLessThan($installPosition);
 });


### PR DESCRIPTION
## What changed

- deploy staging automatically after protected updates to the `staging` branch
- retain manual workflow dispatch for recovery and operational reruns
- queue staging deployments instead of cancelling an SSH deployment mid-run
- add a Pest regression test for the workflow triggers and concurrency behavior

## Why

The existing staging workflow was manual-only and had never run, so merging into `staging` did not deploy the application. Enabling the branch push trigger restores the expected staging delivery flow.

## Validation

- `composer ci:check`
- 1,214 tests, 5,830 assertions, 100.0% coverage
- workflow parsed with `js-yaml`
