### PR TITLE
Upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,16 +19,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup PHP 8.4
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:
           php-version: "8.4"
           extensions: dom, fileinfo, mbstring, sockets
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "20"
+          node-version: "22"
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist
       - name: Prepare environment

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -19,7 +19,7 @@ jobs:
         run: test "$GITHUB_REF" = "refs/heads/staging"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -29,7 +29,7 @@ jobs:
           coverage: xdebug
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -25,7 +25,7 @@ jobs:
           coverage: xdebug
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -27,7 +27,7 @@ jobs:
           coverage: xdebug
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'

--- a/tests/Unit/DeploymentWorkflowTest.php
+++ b/tests/Unit/DeploymentWorkflowTest.php
@@ -4,6 +4,48 @@ declare(strict_types=1);
 
 use Symfony\Component\Yaml\Yaml;
 
+it('uses Node 24-compatible GitHub actions in active workflows', function () {
+    $expectedActions = [
+        'deploy-staging.yml' => [
+            'actions/checkout@v7',
+            'actions/setup-node@v7',
+        ],
+        'deploy.yml' => [
+            'actions/checkout@v7',
+            'actions/setup-node@v7',
+        ],
+        'lint.yml' => [
+            'actions/checkout@v7',
+        ],
+        'tests.yml' => [
+            'actions/checkout@v7',
+            'actions/setup-node@v7',
+        ],
+        'copilot-setup-steps.yml' => [
+            'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1',
+            'actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0',
+            'node-version: "22"',
+        ],
+    ];
+
+    foreach ($expectedActions as $workflowName => $expectedWorkflowActions) {
+        $workflow = file_get_contents(__DIR__.'/../../.github/workflows/'.$workflowName);
+
+        if ($workflow === false) {
+            throw new RuntimeException("Unable to read the {$workflowName} workflow.");
+        }
+
+        expect($workflow)
+            ->not->toContain('actions/checkout@v4')
+            ->not->toContain('actions/setup-node@v4')
+            ->not->toContain('actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020');
+
+        foreach ($expectedWorkflowActions as $expectedWorkflowAction) {
+            expect($workflow)->toContain($expectedWorkflowAction);
+        }
+    }
+});
+
 it('deploys staging automatically and supports manual dispatch', function () {
     $workflow = Yaml::parseFile(__DIR__.'/../../.github/workflows/deploy-staging.yml');
 


### PR DESCRIPTION
## Summary

- upgrade active checkout and setup-node actions to their Node 24-based v7 releases
- update SHA-pinned Copilot setup actions and align its project runtime to Node 22
- add regression coverage preventing deprecated Node 20 action references from returning

## Root cause

GitHub Actions was forcing checkout v4 and setup-node v4 from their deprecated Node 20 runtime to Node 24, producing annotations on CI and staging deployments.

## Validation

- `composer ci:check`
- 1,216 tests, 5,873 assertions
- 100% coverage
- all edited workflows parsed successfully with `js-yaml`
