### PR TITLE
Fix Passport private key deployment permissions

### DIFF
--- a/deployment/ensure-storage-permissions.sh
+++ b/deployment/ensure-storage-permissions.sh
@@ -20,6 +20,13 @@ sudo /usr/bin/chown -R deployer:www-data "${WRITABLE_PATHS[@]}"
 sudo /usr/bin/find "${WRITABLE_PATHS[@]}" -type d -exec /usr/bin/chmod 2775 {} +
 sudo /usr/bin/find "${WRITABLE_PATHS[@]}" -type f -exec /usr/bin/chmod 0664 {} +
 
+# Passport's private key must remain readable by PHP-FPM without being
+# group-writable. The broad storage normalization above would otherwise make
+# Passport reject the key during authorization requests.
+if [[ -f "$APP_DIR/storage/oauth-private.key" ]]; then
+    sudo /usr/bin/chmod 0660 "$APP_DIR/storage/oauth-private.key"
+fi
+
 # Report generation creates this directory on demand. Creating it here also
 # makes its ownership explicit before the backup scheduler traverses storage.
 sudo /usr/bin/install -d -o deployer -g www-data -m 2775 "$APP_DIR/storage/app/private/reports"

--- a/deployment/setup-server.sh
+++ b/deployment/setup-server.sh
@@ -33,6 +33,7 @@ cat > /etc/sudoers.d/familyfunds-storage-permissions << 'EOF'
 deployer ALL=(root) NOPASSWD: /usr/bin/chown -R deployer:www-data /var/www/contribution-tracker/storage /var/www/contribution-tracker/bootstrap/cache
 deployer ALL=(root) NOPASSWD: /usr/bin/find /var/www/contribution-tracker/storage /var/www/contribution-tracker/bootstrap/cache -type d -exec /usr/bin/chmod 2775 {} +
 deployer ALL=(root) NOPASSWD: /usr/bin/find /var/www/contribution-tracker/storage /var/www/contribution-tracker/bootstrap/cache -type f -exec /usr/bin/chmod 0664 {} +
+deployer ALL=(root) NOPASSWD: /usr/bin/chmod 0660 /var/www/contribution-tracker/storage/oauth-private.key
 deployer ALL=(root) NOPASSWD: /usr/bin/install -d -o deployer -g www-data -m 2775 /var/www/contribution-tracker/storage/app/private/reports
 EOF
 chmod 440 /etc/sudoers.d/deployer /etc/sudoers.d/familyfunds-storage-permissions

--- a/tests/Unit/DeploymentStoragePermissionsTest.php
+++ b/tests/Unit/DeploymentStoragePermissionsTest.php
@@ -13,11 +13,13 @@ it('normalizes storage permissions before production deployment completes', func
         ->toContain('chown -R deployer:www-data')
         ->toContain('find "${WRITABLE_PATHS[@]}" -type d -exec /usr/bin/chmod 2775')
         ->toContain('find "${WRITABLE_PATHS[@]}" -type f -exec /usr/bin/chmod 0664')
+        ->toContain('chmod 0660 "$APP_DIR/storage/oauth-private.key"')
         ->toContain('storage/app/private/reports');
 
     expect($setupScript)
         ->toContain('/etc/sudoers.d/familyfunds-storage-permissions')
         ->toContain('/usr/bin/chown -R deployer:www-data /var/www/contribution-tracker/storage /var/www/contribution-tracker/bootstrap/cache')
+        ->toContain('/usr/bin/chmod 0660 /var/www/contribution-tracker/storage/oauth-private.key')
         ->toContain('/usr/bin/install -d -o deployer -g www-data -m 2775 /var/www/contribution-tracker/storage/app/private/reports');
 
     expect($deployScript)->toContain('bash deployment/ensure-storage-permissions.sh "$APP_DIR"');


### PR DESCRIPTION
Closes #240

## Summary

- keep the broad Laravel writable-path normalization for storage and bootstrap cache
- restore Passport's private key to mode `0660` after that normalization
- add the exact sudoers permission and regression assertions

This addresses Nightwatch production exception #30, where `GET /oauth/authorize` returned HTTP 500 because `storage/oauth-private.key` was mode `0664`.

## Verification

- `bash -n deployment/ensure-storage-permissions.sh deployment/setup-server.sh deployment/deploy.sh`
- `git diff --check`
- Pint passed
- Focused Pest execution is blocked in this numeric worktree path because Pest derives an invalid namespace from directory `2989`; hosted CI should be used for the authoritative test run.

Production deployment and Nightwatch resolution remain pending merge/deploy.